### PR TITLE
fix: broken source links — NSA CSfC restructure, CCDB-014 moved, atsec relative URLs

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -21,6 +21,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import feedparser
 import requests
 from bs4 import BeautifulSoup
+from urllib.parse import urljoin
 from datetime import datetime, timezone
 
 import config
@@ -311,11 +312,14 @@ def scrapelab_items(url):
     for tag in soup.find_all(["h2", "h3", "h4", "article"]):
         a = tag.find("a") if tag.name != "a" else tag
         if a and a.get_text(strip=True):
+            href = a.get("href", "")
+            if href:
+                href = urljoin(url, href)
             items.append({
                 "title":     a.get_text(strip=True),
-                "link":      a.get("href", ""),
+                "link":      href,
                 "published": "",
-                "id":        a.get("href", a.get_text(strip=True)),
+                "id":        href or a.get_text(strip=True),
             })
     return items[:20]
 

--- a/config.py
+++ b/config.py
@@ -311,8 +311,8 @@ CC_CRYPTO_DOCS = {
                     "Specification_of_Functional_Requirements_for_Cryptography.pdf"
         ),
         "CCDB-014 v3.1 Assurance Continuity (Feb 2024)": (
-                    "https://www.commoncriteriaportal.org/files/ccfiles/"
-                    "CCDB-014-v3.1-2024-February-29.pdf"
+                    "https://www.commoncriteriaportal.org/files/operatingprocedures/"
+                    "CCDB-014-v3.1-2024-February-29-Final-Assurance_Continuity.pdf"
         ),
         "CC:2022 Part 2 Security Functional Requirements": (
                     "https://www.commoncriteriaportal.org/files/ccfiles/CC2022PART2R1.pdf"

--- a/config.py
+++ b/config.py
@@ -185,12 +185,12 @@ BODY_WATCH_KEYWORDS = [
 CSFC_BASE = "https://www.nsa.gov"
 
 CSFC_PAGES = {
-        "home":          "/resources/everyone/csfc/",
-        "apl":           "/resources/everyone/csfc/approved-products-list/",
-        "cap_packages":  "/resources/everyone/csfc/capability-packages/",
-        "faq":           "/resources/everyone/csfc/faqs/",
-        "registration":  "/resources/everyone/csfc/registration/",
-        "kmr":           "/resources/everyone/csfc/key-management/",
+        "home":          "/Resources/Commercial-Solutions-for-Classified-Program/",
+        "apl":           "/Resources/Commercial-Solutions-for-Classified-Program/Components-List/",
+        "cap_packages":  "/Resources/Commercial-Solutions-for-Classified-Program/Capability-Packages/",
+        "faq":           "/Resources/Commercial-Solutions-for-Classified-Program/faq/",
+        "registration":  "/Resources/Commercial-Solutions-for-Classified-Program/Solution-Registration/",
+        "kmr":           "/Resources/Commercial-Solutions-for-Classified-Program/Customer-Handbook/",
         "announcements": "/Resources/Commercial-Solutions-for-Classified-Program/Announcements/",
 }
 
@@ -227,7 +227,7 @@ CSFC_COMPONENTS_LIST_URL = "https://www.nsa.gov/Resources/Commercial-Solutions-f
 CSFC_PRODUCT_LIST_URL = "https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/"
 
 CSFC_FEEDS = [
-        {"name": "NSA Cybersecurity Advisories", "rss": "https://www.nsa.gov/rss/rssfeed.aspx?POIID=9", "scrape": False},
+        {"name": "NSA Cybersecurity Advisories", "rss": "https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=1282&max=20", "scrape": False},
         {"name": "CISA Alerts",                  "rss": "https://www.cisa.gov/cybersecurity-advisories/all.xml", "scrape": False},
         {"name": "DISA STIGs & APL News",        "rss": None, "url": "https://public.cyber.mil/stigs/", "scrape": True},
 ]

--- a/dashboard.py
+++ b/dashboard.py
@@ -447,10 +447,10 @@ DASHBOARD_TEMPLATE = """
       </div>
       <div class="sources-group">
         <div class="sources-group-title">🇳🇮 CSfC (Commercial Solutions for Classified)</div>
-        <div class="sources-item"><span class="src-label">Main:</span><a href="https://www.nsa.gov/resources/everyone/csfc/" target="_blank" rel="noopener">nsa.gov &mdash; CSfC Home</a></div>
+        <div class="sources-item"><span class="src-label">Main:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/" target="_blank" rel="noopener">nsa.gov &mdash; CSfC Home</a></div>
         <div class="sources-item"><span class="src-label">Components List:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/" target="_blank" rel="noopener">nsa.gov &mdash; CSfC APL Components</a></div>
-        <div class="sources-item"><span class="src-label">Capability Packages:</span><a href="https://www.nsa.gov/resources/everyone/csfc/capability-packages/" target="_blank" rel="noopener">nsa.gov &mdash; Capability Packages</a></div>
-        <div class="sources-item"><span class="src-label">NSA Advisories (RSS):</span><a href="https://www.nsa.gov/rss/rssfeed.aspx?POIID=9" target="_blank" rel="noopener">nsa.gov &mdash; Cybersecurity RSS</a></div>
+        <div class="sources-item"><span class="src-label">Capability Packages:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Capability-Packages/" target="_blank" rel="noopener">nsa.gov &mdash; Capability Packages</a></div>
+        <div class="sources-item"><span class="src-label">NSA Advisories (RSS):</span><a href="https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=1282&max=20" target="_blank" rel="noopener">nsa.gov &mdash; Cybersecurity RSS</a></div>
         <div class="sources-item"><span class="src-label">CISA Alerts (RSS):</span><a href="https://www.cisa.gov/cybersecurity-advisories/all.xml" target="_blank" rel="noopener">cisa.gov &mdash; All Advisories</a></div>
       </div>
       <div class="sources-group">
@@ -486,7 +486,7 @@ DASHBOARD_TEMPLATE = """
       <div class="sources-group">
         <div class="sources-group-title">🔒 CC Crypto Catalog (CCDB-018)</div>
         <div class="sources-item"><span class="src-label">CCDB-018 v1.0 (Jan 2025):</span><a href="https://www.commoncriteriaportal.org/files/ccfiles/CCDB-018-v1.0-2025-Jan-31-Final-Specification_of_Functional_Requirements_for_Cryptography.pdf" target="_blank" rel="noopener">commoncriteriaportal.org &mdash; CCDB-018 PDF</a></div>
-        <div class="sources-item"><span class="src-label">CCDB-014 v3.1:</span><a href="https://www.commoncriteriaportal.org/files/ccfiles/CCDB-014-v3.1-2024-February-29.pdf" target="_blank" rel="noopener">commoncriteriaportal.org &mdash; CCDB-014 PDF</a></div>
+        <div class="sources-item"><span class="src-label">CCDB-014 v3.1:</span><a href="https://www.commoncriteriaportal.org/files/operatingprocedures/CCDB-014-v3.1-2024-February-29-Final-Assurance_Continuity.pdf" target="_blank" rel="noopener">commoncriteriaportal.org &mdash; CCDB-014 PDF</a></div>
         <div class="sources-item"><span class="src-label">CC:2022 Part 2:</span><a href="https://www.commoncriteriaportal.org/files/ccfiles/CC2022PART2R1.pdf" target="_blank" rel="noopener">commoncriteriaportal.org &mdash; CC:2022 SFRs PDF</a></div>
       </div>
     </div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -450,7 +450,7 @@ DASHBOARD_TEMPLATE = """
         <div class="sources-item"><span class="src-label">Main:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/" target="_blank" rel="noopener">nsa.gov &mdash; CSfC Home</a></div>
         <div class="sources-item"><span class="src-label">Components List:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/" target="_blank" rel="noopener">nsa.gov &mdash; CSfC APL Components</a></div>
         <div class="sources-item"><span class="src-label">Capability Packages:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Capability-Packages/" target="_blank" rel="noopener">nsa.gov &mdash; Capability Packages</a></div>
-        <div class="sources-item"><span class="src-label">NSA Advisories (RSS):</span><a href="https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=1282&max=20" target="_blank" rel="noopener">nsa.gov &mdash; Cybersecurity RSS</a></div>
+        <div class="sources-item"><span class="src-label">NSA Advisories (RSS):</span><a href="https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&amp;Site=1282&amp;max=20" target="_blank" rel="noopener">nsa.gov &mdash; Cybersecurity RSS</a></div>
         <div class="sources-item"><span class="src-label">CISA Alerts (RSS):</span><a href="https://www.cisa.gov/cybersecurity-advisories/all.xml" target="_blank" rel="noopener">cisa.gov &mdash; All Advisories</a></div>
       </div>
       <div class="sources-group">


### PR DESCRIPTION
Closes #6

Fixes three categories of broken links found during a full URL audit of the repo.

**1. NSA CSfC restructure (`config.py` + `dashboard.py`)** — All `/resources/everyone/csfc/` paths return 404. Updated all 6 `CSFC_PAGES` keys to the new `/Resources/Commercial-Solutions-for-Classified-Program/` base, replaced dead RSS feed, and mirrored fixes in `dashboard.py` sources modal.

**2. CCDB-014 PDF moved (`config.py` + `dashboard.py`)** — File moved from `/files/ccfiles/` to `/files/operatingprocedures/` with a new longer filename. Fixed in both files.

**3. atsec relative URLs (`collector.py`)** — `scrapelab_items()` was storing raw relative hrefs like `/post-slug/` from the atsec blog. These resolved to `kr15tyk.github.io/post-slug/` (GitHub Pages 404) instead of `www.atsec.com/post-slug/`. Added `urljoin(url, href)` to resolve links against the scraped page's base domain.

Note: NIAP product/PP detail links are also broken (auth wall) but skipped — requires a NIAP login to verify new URL format.