### PR TITLE
fix: wave 2 — CSfC APL double GET, CSFC_PRODUCT_LIST_URL, dead cctls endpoint

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -692,6 +692,35 @@ def collect_all():
 
 
 # ── CSfC (Commercial Solutions for Classified) ────────────────────────────────
+def _scrape_csfc_page_from_soup(soup) -> list:
+    """Scrape a pre-fetched NSA CSfC page soup and return a list of text/link items.
+    Used by collect_csfc() for the APL page so soup is only fetched once (fix #24).
+    """
+    if not soup:
+        return []
+    items = []
+    content = (
+        soup.find("div", {"id": "ContentPane"})
+        or soup.find("main")
+        or soup.find("div", class_="field-items")
+        or soup
+    )
+    for tag in content.find_all(["p", "li", "h2", "h3", "h4"]):
+        text = tag.get_text(separator=" ", strip=True)
+        link = tag.find("a")
+        href = link["href"] if link and link.get("href") else ""
+        if len(text) > 15:
+            items.append({"text": text[:400], "href": href})
+    seen: set = set()
+    unique: list = []
+    for item in items:
+        key = item["text"][:80]
+        if key not in seen:
+            seen.add(key)
+            unique.append(item)
+    return unique
+
+
 def _scrape_csfc_page(path: str) -> list:
     """Scrape a single NSA CSfC page and return a list of text/link items."""
     url = config.CSFC_BASE + path
@@ -834,12 +863,17 @@ def collect_csfc() -> dict:
     # 1. Scrape CSfC pages; for the APL, also parse structured records (fix #18)
     for page_key, path in config.CSFC_PAGES.items():
         log.debug("  [CSfC] Scraping page: %s (%s)...", page_key, path)
-        data["pages"][page_key] = _scrape_csfc_page(path)
-        log.debug("    -> %d items", len(data["pages"][page_key]))
         if page_key == "apl":
+            # fix #24: fetch APL page once; reuse soup for both parsers to avoid
+            # double GET on a WAF-protected NSA URL that intermittently 403s.
             apl_soup = get_html(config.CSFC_BASE + path)
+            data["pages"][page_key] = _scrape_csfc_page_from_soup(apl_soup)
             data["apl_structured"] = _parse_csfc_apl_structured(apl_soup)
-            log.debug("    -> %d structured APL records", len(data["apl_structured"]))
+            log.debug("    -> %d items, %d structured APL records",
+                      len(data["pages"][page_key]), len(data["apl_structured"]))
+        else:
+            data["pages"][page_key] = _scrape_csfc_page(path)
+            log.debug("    -> %d items", len(data["pages"][page_key]))
 
     # 2. Download and SHA-256 hash Component Selections PDFs
     log.info(" [CSfC] Hashing Component Selections PDFs...")

--- a/config.py
+++ b/config.py
@@ -229,7 +229,7 @@ CSFC_COMPONENTS_LIST_URL = "https://www.nsa.gov/Resources/Commercial-Solutions-f
 
 # -- CSfC Product List (approved products) ----------------------------------
 # Monitored separately from component selections for Cisco-specific alerting.
-CSFC_PRODUCT_LIST_URL = "https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/"
+CSFC_PRODUCT_LIST_URL = "https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/"  # fix #24: TODO — update to actual APL product URL when confirmed
 
 CSFC_FEEDS = [
     {"name": "NSA Cybersecurity Advisories", "rss": "https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=1282&max=20", "scrape": False},

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ def _empty_snapshot() -> dict:
     return {
         "schema_version": config.SNAPSHOT_SCHEMA_VERSION,
         "collected_at": "",
-        "niap":      {"pcl": [], "pps": [], "tds": [], "cctls": [], "events": [], "news": []},
+        "niap": {"pcl": [], "pps": [], "tds": [], "events": [], "news": []}  # fix #26: removed dead "cctls" key,
         "cc_portal": {"news": [], "pps": [], "products": [], "communities": [], "publications": [], "pp_rss": []},
         "cctl_labs": {},
         "csfc":      {"pages": {}, "capability_package_headers": {}, "feeds": {}},


### PR DESCRIPTION
Closes #24, closes #26.

## Summary

Three cleanup fixes across `collector.py`, `config.py`, and `main.py`.

---

## Fix #24 — CSfC APL double GET

**`collector.py` — `collect_csfc()`**
The APL page was fetched twice per run: once inside `_scrape_csfc_page(path)` and once again as `get_html(CSFC_BASE + path)` to build `apl_structured`. The NSA APL URL is WAF-protected and intermittently returns 403 on repeated rapid requests — doubling the fetch risk unnecessarily.

Fix: Added `_scrape_csfc_page_from_soup(soup)` helper that accepts a pre-fetched soup. `collect_csfc()` now calls `get_html()` once for the APL path and passes the soup to both `_scrape_csfc_page_from_soup` and `_parse_csfc_apl_structured`.

**`config.py` — `CSFC_PRODUCT_LIST_URL`**
This constant was identical to `CSFC_COMPONENTS_LIST_URL`. Added a `TODO` comment flagging the duplicate so the correct APL product page URL can be confirmed.

---

## Fix #26 — Dead `cctls` endpoint

**`main.py` — `_empty_snapshot()`**
Removed `"cctls": []` from the `niap` section. `collect_niap()` never populates this key; CCTL lab data is collected separately under the top-level `cctl_labs` key by `collect_cctl_labs()`.