### PR TITLE
fix: wave 3 — EST hardcoded timezone replaced with ZoneInfo("America/New_York") for EDT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CC Pulse monitors these sources daily:
 | **CCTL Labs** | New posts from accredited Common Criteria evaluation labs |
 | **NIST CSRC** | Cryptography news, FIPS publications, CMVP, and post-quantum standards |
 
-It runs automatically every day at **01:00 EST** and posts to this space only when something relevant is found.
+It runs automatically every day at **06:00 UTC / 01:00 ET** (adjusts for EDT in summer) and posts to this space only when something relevant is found.
 
 ---
 

--- a/emailer.py
+++ b/emailer.py
@@ -24,7 +24,8 @@ import urllib.error
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from datetime import datetime, timezone, timedelta
-EST = timezone(timedelta(hours=-5))
+from zoneinfo import ZoneInfo
+ET = ZoneInfo("America/New_York")  # fix #25: was EST = timezone(timedelta(hours=-5)) — wrong during EDT
 import config
 
 log = logging.getLogger(__name__)
@@ -367,7 +368,7 @@ def _section(title: str, rows: list[str]) -> str:
 # ---------------------------------------------------------------------------
 
 def build_email_html(weekly_diff: dict) -> str:
-    now  = datetime.now(EST)
+    now  = datetime.now(ET)
     date = now.strftime("%B %d, %Y")
     parts: list[str] = []
 
@@ -528,7 +529,7 @@ def build_email_html(weekly_diff: dict) -> str:
     parts.append(_section("NIST CSRC — Standards, CMVP & PQC", rows))
 
     body      = "".join(parts) or "<p>No changes detected this week.</p>"
-    generated = datetime.now(EST).strftime("%Y-%m-%d %H:%M EST")
+    generated = datetime.now(ET).strftime("%Y-%m-%d %H:%M ET")
     return (
         '<html><body style="font-family:-apple-system,BlinkMacSystemFont,sans-serif;'
         'max-width:720px;margin:0 auto;color:#E0E7FF">'
@@ -580,7 +581,7 @@ def _send_email(subject: str, html: str) -> None:
 
 def send_weekly_email(weekly_diff: dict) -> None:
     """Build and send the weekly HTML email digest."""
-    date_str = datetime.now(EST).strftime("%Y-%m-%d")
+    date_str = datetime.now(ET).strftime("%Y-%m-%d")
     subject  = config.EMAIL_SUBJECT.format(date=date_str)
     html     = build_email_html(weekly_diff)
     _send_email(subject, html)
@@ -595,7 +596,7 @@ def send_alert_email(alerts: list[dict]) -> None:
     if not alerts:
         return
 
-    date_str   = datetime.now(EST).strftime("%Y-%m-%d")
+    date_str   = datetime.now(ET).strftime("%Y-%m-%d")
     tier1_count = sum(1 for a in alerts if _alert_tier(a) == 1)
     subject    = (
         f"CC Pulse ALERT \u2014 {tier1_count} Cisco-relevant + {len(alerts)-tier1_count} other match(es) on {date_str}"
@@ -669,7 +670,7 @@ def send_alert_email(alerts: list[dict]) -> None:
         + dashboard_link
     )
 
-    generated = datetime.now(EST).strftime("%Y-%m-%d %H:%M EST")
+    generated = datetime.now(ET).strftime("%Y-%m-%d %H:%M ET")
     html = (
         '<html><body style="font-family:-apple-system,BlinkMacSystemFont,sans-serif;'
         'max-width:720px;margin:0 auto;color:#E0E7FF">'
@@ -900,7 +901,7 @@ def send_cisco_cert_email(new_certs: list[dict]) -> None:
     if not new_certs:
         return
 
-    date_str  = datetime.now(EST).strftime("%Y-%m-%d")
+    date_str  = datetime.now(ET).strftime("%Y-%m-%d")
     count     = len(new_certs)
     cert_word = "Certification" if count == 1 else "Certifications"
     subject   = f"\U0001f3c6 CC Pulse \u2014 {count} New Cisco NDcPP {cert_word} on {date_str}"
@@ -963,7 +964,7 @@ def send_cisco_cert_email(new_certs: list[dict]) -> None:
         '</p>'
     )
 
-    generated = datetime.now(EST).strftime("%Y-%m-%d %H:%M EST")
+    generated = datetime.now(ET).strftime("%Y-%m-%d %H:%M ET")
     html = (
         '<html><body style="font-family:-apple-system,BlinkMacSystemFont,sans-serif;'
         'max-width:720px;margin:0 auto;color:#E0E7FF">'
@@ -1025,7 +1026,7 @@ def send_readme_message() -> None:
         "| **CC Portal** | International CC news, Protection Profiles, and certified products |\n"
         "| **CCTL Labs** | New posts from accredited Common Criteria evaluation labs |\n"
         "| **NIST CSRC** | Cryptography news, FIPS publications, CMVP, and post-quantum standards |\n\n"
-        "Runs automatically every day at **01:00 EST** and posts here only when something relevant is found.\n\n"
+        "Runs automatically every day at **06:00 UTC / 01:00 ET** (adjusts for EDT in summer) and posts here only when something relevant is found.\n\n"
         "---\n\n"
         "## Dashboard Navigation\n\n"
         "The dashboard has three tabs:\n\n"
@@ -1092,7 +1093,7 @@ def send_workflow_failure_alert(
             f"https://github.com/kr15tyk/CC-pulse/actions/runs/{run_id}"
         )
 
-    ts = datetime.now(EST).strftime("%Y-%m-%d %H:%M EST")
+    ts = datetime.now(ET).strftime("%Y-%m-%d %H:%M ET")
     run_link = f"[View failed run]({run_url})" if run_url else "Check the Actions tab for details."
 
     msg = (


### PR DESCRIPTION
Closes #25.

## Summary

Fixes the hardcoded `EST = timezone(timedelta(hours=-5))` constant in `emailer.py` which was always UTC-5, causing timestamps to be 1 hour behind during EDT (mid-March through early November — roughly 8 months of the year).

## Changes

### `emailer.py`
- Added `from zoneinfo import ZoneInfo` (stdlib since Python 3.9)
- Replaced `EST = timezone(timedelta(hours=-5))` with `ET = ZoneInfo("America/New_York")` — automatically handles EST/EDT transitions
- Updated all `datetime.now(EST)` calls → `datetime.now(ET)`
- Updated all strftime format strings from `"%Y-%m-%d %H:%M EST"` → `"%Y-%m-%d %H:%M ET"`
- Updated `send_readme_message()` body: `01:00 EST` → `06:00 UTC / 01:00 ET`

### `README.md`
- Updated run schedule line: `01:00 EST` → `06:00 UTC / 01:00 ET (adjusts for EDT in summer)`

## Affected locations

`build_email_html()`, `send_weekly_email()`, `send_alert_email()`, `send_cisco_cert_email()`, `send_workflow_failure_alert()`, `send_readme_message()` — all now use `ET` (correct DST-aware Eastern Time).