### PR TITLE
Fix stored XSS in dashboard/email output + restore weekly digest

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -299,7 +299,7 @@ DASHBOARD_TEMPLATE = """
 <meta charset="UTF-8">
 <meta http-equiv="refresh" content="3600">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-{{ noindex_meta }}
+{{ noindex_meta | safe }}
 <title>CC Pulse Dashboard</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
@@ -616,7 +616,7 @@ DASHBOARD_TEMPLATE = """
     {% for alert in diff.alerts %}
         <div class="item-row alert-item" data-alert-key="{{ alert.source }}-{{ alert.title | replace(' ', '_') }}" data-tab="{{ alert.tab }}">
           {% if alert.url %}
-          <a class="item-link" href="{{ alert.url }}" target="_blank">{{ alert.source }}: {{ alert.title }}</a>
+          <a class="item-link" href="{{ (alert.url) | safe_url }}" target="_blank">{{ alert.source }}: {{ alert.title }}</a>
           {% else %}
           <span class="item-link">{{ alert.source }}: {{ alert.title }}</span>
           {% endif %}
@@ -735,7 +735,7 @@ DASHBOARD_TEMPLATE = """
         <div class="sub-hdr sub-{{ css_kind }}">{{ group_name }} — {{ label }} ({{ changes.get(kind, []) | length }})</div>
         {% for item in changes.get(kind, []) %}
         <div class="item-row" data-source="niap-news" data-kind="{{ css_kind }}">
-          <a class="item-link" href="{{ item.link or item.url or 'https://www.niap-ccevs.org/announcements' }}" target="_blank">{{ item.title or item.name or 'NIAP item' }}</a>
+          <a class="item-link" href="{{ (item.link or item.url or 'https://www.niap-ccevs.org/announcements') | safe_url }}" target="_blank">{{ item.title or item.name or 'NIAP item' }}</a>
           <span class="item-meta">{{ (item.posted or item.date or item.start_date or item.moddate or '')[:10] }}</span>
         </div>
         {% endfor %}
@@ -759,7 +759,7 @@ DASHBOARD_TEMPLATE = """
       <div class="sub-hdr sub-{{ css_kind }}">{{ label }} ({{ diff.niap.policies.get(kind, []) | length }})</div>
       {% for policy in diff.niap.policies.get(kind, []) %}
       <div class="item-row" data-source="niap-policies" data-kind="{{ css_kind }}">
-        <a class="item-link" href="{{ policy.url or 'https://www.niap-ccevs.org/policies' }}" target="_blank">Policy {{ policy.policy_num }}{% if policy.update_num %}, Update {{ policy.update_num }}{% endif %} — {{ policy.policy_title or policy.title }}</a>
+        <a class="item-link" href="{{ (policy.url or 'https://www.niap-ccevs.org/policies') | safe_url }}" target="_blank">Policy {{ policy.policy_num }}{% if policy.update_num %}, Update {{ policy.update_num }}{% endif %} — {{ policy.policy_title or policy.title }}</a>
         <span class="item-meta">{{ (policy.policy_date or policy.moddate or '')[:10] }}</span>
       </div>
       {% endfor %}
@@ -915,7 +915,7 @@ DASHBOARD_TEMPLATE = """
     {% for cp_name, cp in diff.csfc.selection_links.items() %}
     {% if cp.changed %}
     <div class="cp-row" data-source="csfc" data-kind="updated">
-      <a class="item-link" href="{{ cp.new_href or cp.old_href or config_csfc_components_url }}" target="_blank">{{ cp_name }}</a>
+      <a class="item-link" href="{{ (cp.new_href or cp.old_href or config_csfc_components_url) | safe_url }}" target="_blank">{{ cp_name }}</a>
       <div class="cp-detail">
         <span class="cp-date">Selection document link changed</span>
       </div>
@@ -926,13 +926,13 @@ DASHBOARD_TEMPLATE = """
       {% if page_key in ['apl', 'announcements'] %}
         {% for item in page_diff.added %}
         <div class="item-row" data-source="csfc" data-kind="new">
-          <a class="item-link" href="{{ item.href or (config_csfc_components_url if page_key == 'apl' else config_csfc_announcements_url) }}" target="_blank">{{ item.text }}</a>
+          <a class="item-link" href="{{ (item.href or (config_csfc_components_url if page_key == 'apl' else config_csfc_announcements_url)) | safe_url }}" target="_blank">{{ item.text }}</a>
           <span class="item-meta">{% if page_key == 'apl' %}component added{% else %}announcement added{% endif %}</span>
         </div>
         {% endfor %}
         {% for item in page_diff.removed %}
         <div class="item-row" data-source="csfc" data-kind="removed">
-          <a class="item-link" href="{{ item.href or (config_csfc_components_url if page_key == 'apl' else config_csfc_announcements_url) }}" target="_blank">{{ item.text }}</a>
+          <a class="item-link" href="{{ (item.href or (config_csfc_components_url if page_key == 'apl' else config_csfc_announcements_url)) | safe_url }}" target="_blank">{{ item.text }}</a>
           <span class="item-meta">{% if page_key == 'apl' %}component removed{% else %}announcement removed{% endif %}</span>
         </div>
         {% endfor %}
@@ -957,7 +957,7 @@ DASHBOARD_TEMPLATE = """
     {% for page_key, page_diff in diff.cc_crypto.pages.items() %}
       {% for item in page_diff.added %}
       <div class="item-row" data-source="cc-crypto" data-kind="updated">
-        <a class="item-link" href="{{ item.href or 'https://www.commoncriteriaportal.org/' }}" target="_blank">{{ item.text or page_key }}</a>
+        <a class="item-link" href="{{ (item.href or 'https://www.commoncriteriaportal.org/') | safe_url }}" target="_blank">{{ item.text or page_key }}</a>
         <span class="item-meta">{{ page_key }}</span>
       </div>
       {% endfor %}
@@ -978,7 +978,7 @@ DASHBOARD_TEMPLATE = """
     {% for page_key, page_diff in diff.nist.pages.items() %}
       {% for item in page_diff.added %}
       <div class="item-row" data-source="nist" data-kind="updated">
-        <a class="item-link" href="{{ item.href or 'https://csrc.nist.gov/' }}" target="_blank">{{ item.text or page_key }}</a>
+        <a class="item-link" href="{{ (item.href or 'https://csrc.nist.gov/') | safe_url }}" target="_blank">{{ item.text or page_key }}</a>
         <span class="item-meta">{{ page_key }}</span>
       </div>
       {% endfor %}
@@ -1005,7 +1005,7 @@ DASHBOARD_TEMPLATE = """
     <div class="sub-hdr sub-new">News ({{ diff.cc_portal.news.added | length }})</div>
     {% for item in diff.cc_portal.news.added %}
     <div class="item-row" data-source="cc-portal" data-kind="new">
-      <a class="item-link" href="{{ item.link or item.url or 'https://www.commoncriteriaportal.org/' }}" target="_blank">{{ item.title or item.text or item }}</a>
+      <a class="item-link" href="{{ (item.link or item.url or 'https://www.commoncriteriaportal.org/') | safe_url }}" target="_blank">{{ item.title or item.text or item }}</a>
       <span class="item-meta">{{ item.date or '' }}</span>
     </div>
     {% endfor %}
@@ -1014,7 +1014,7 @@ DASHBOARD_TEMPLATE = """
     <div class="sub-hdr sub-new">New International PPs ({{ diff.cc_portal.pps.added | length }})</div>
     {% for pp in diff.cc_portal.pps.added %}
     <div class="item-row" data-source="cc-portal" data-kind="new">
-      <a class="item-link" href="{{ pp.link or 'https://www.commoncriteriaportal.org/pps/' }}" target="_blank">{{ pp.title or pp.text or pp }}</a>
+      <a class="item-link" href="{{ (pp.link or 'https://www.commoncriteriaportal.org/pps/') | safe_url }}" target="_blank">{{ pp.title or pp.text or pp }}</a>
       <span class="item-meta"></span>
     </div>
     {% endfor %}
@@ -1042,7 +1042,7 @@ DASHBOARD_TEMPLATE = """
             <div class="sub-hdr sub-new">New Cisco NATO Listings ({{ diff.nato.cisco_added | length }})</div>
             {% for item in diff.nato.cisco_added %}
             <div class="item-row" data-source="nato" data-kind="new">
-              <a class="item-link" href="{{ item.link or config_nato_url }}" target="_blank">{{ item.name or item.raw_text }}</a>
+              <a class="item-link" href="{{ (item.link or config_nato_url) | safe_url }}" target="_blank">{{ item.name or item.raw_text }}</a>
               <span class="item-meta">{{ item.manufacturer or '' }}</span>
             </div>
             {% endfor %}
@@ -1053,7 +1053,7 @@ DASHBOARD_TEMPLATE = """
             <div class="sub-hdr sub-new">{{ page_key }} — New Items ({{ page_diff.added | length }})</div>
             {% for item in page_diff.added %}
             <div class="item-row" data-source="nato" data-kind="new">
-              <a class="item-link" href="{{ item.link or item.href or '#' }}" target="_blank">{{ item.name or item.text or item.raw_text or item }}</a>
+              <a class="item-link" href="{{ (item.link or item.href or '#') | safe_url }}" target="_blank">{{ item.name or item.text or item.raw_text or item }}</a>
               <span class="item-meta"></span>
             </div>
             {% endfor %}
@@ -1086,7 +1086,7 @@ DASHBOARD_TEMPLATE = """
       <div class="lab-body collapsed">
         {% for item in lab_items %}
         <div class="item-row" data-source="cctl" data-kind="new">
-          <a class="item-link" href="{{ item.link }}" target="_blank">{{ item.title }}</a>
+          <a class="item-link" href="{{ (item.link) | safe_url }}" target="_blank">{{ item.title }}</a>
           <span class="item-meta">{{ item.published }}</span>
         </div>
         {% endfor %}
@@ -1114,7 +1114,7 @@ DASHBOARD_TEMPLATE = """
             {% if diff.eucc.pages and diff.eucc.pages.requirements %}
             {% for item in diff.eucc.pages.requirements.added %}
             <div class="item-row" data-source="eucc" data-kind="updated">
-              <a class="item-link" href="{{ item.href or '#' }}" target="_blank">{{ item.text or item.name or item }}</a>
+              <a class="item-link" href="{{ (item.href or '#') | safe_url }}" target="_blank">{{ item.text or item.name or item }}</a>
               <span class="item-meta"></span>
             </div>
             {% endfor %}
@@ -1134,7 +1134,7 @@ DASHBOARD_TEMPLATE = """
             <div class="sub-hdr sub-new">New Cisco EUCC Certifications ({{ diff.eucc.cisco_added | length }})</div>
             {% for item in diff.eucc.cisco_added %}
             <div class="item-row" data-source="eucc" data-kind="new">
-              <a class="item-link" href="{{ item.href or '#' }}" target="_blank">{{ item.name or item.text }}</a>
+              <a class="item-link" href="{{ (item.href or '#') | safe_url }}" target="_blank">{{ item.name or item.text }}</a>
               <span class="item-meta"></span>
             </div>
             {% endfor %}
@@ -1142,7 +1142,7 @@ DASHBOARD_TEMPLATE = """
             {% if diff.eucc.pages and diff.eucc.pages.certificates %}
             {% for item in diff.eucc.pages.certificates.added %}
             <div class="item-row" data-source="eucc" data-kind="new">
-              <a class="item-link" href="{{ item.href or '#' }}" target="_blank">{{ item.name or item.text or item }}</a>
+              <a class="item-link" href="{{ (item.href or '#') | safe_url }}" target="_blank">{{ item.name or item.text or item }}</a>
               <span class="item-meta"></span>
             </div>
             {% endfor %}
@@ -1184,7 +1184,7 @@ DASHBOARD_TEMPLATE = """
         <div class="tl-body">
           <div class="tl-title">
             <span class="tl-badge {{ entry.kind }}">{{ entry.kind }}</span>
-            {% if entry.url %}<a href="{{ entry.url }}" target="_blank">{{ entry.title }}</a>{% else %}{{ entry.title }}{% endif %}
+            {% if entry.url %}<a href="{{ (entry.url) | safe_url }}" target="_blank">{{ entry.title }}</a>{% else %}{{ entry.title }}{% endif %}
           </div>
           {% if entry.detail %}<div class="tl-detail">{{ entry.detail }}</div>{% endif %}
         </div>
@@ -1483,7 +1483,7 @@ def _build_rss(diff: dict, generated_at: str) -> str:
         title = f"New PP: {pp.get('pp_short_name', '')}"
         link  = f"https://www.niap-ccevs.org/Profile/PP.cfm?id={pp.get('pp_id', '')}"
         items_xml.append(
-            f"<item><title>{xml_escape(title)}</title><link>{link}</link>"
+            f"<item><title>{xml_escape(title)}</title><link>{xml_escape(link)}</link>"
             f"<description>{xml_escape(pp.get('pp_name', ''))}</description></item>"
         )
 
@@ -1491,7 +1491,7 @@ def _build_rss(diff: dict, generated_at: str) -> str:
         title = f"Removed PP: {pp.get('pp_short_name', '')}"
         link  = f"https://www.niap-ccevs.org/Profile/PP.cfm?id={pp.get('pp_id', '')}"
         items_xml.append(
-            f"<item><title>{xml_escape(title)}</title><link>{link}</link>"
+            f"<item><title>{xml_escape(title)}</title><link>{xml_escape(link)}</link>"
             f"<description>{xml_escape(pp.get('pp_name', ''))}</description></item>"
         )
 
@@ -1535,7 +1535,7 @@ def _build_rss(diff: dict, generated_at: str) -> str:
             title = f"[{lab}] {it.get('title', '')}"
             link  = it.get("link", "#")
             items_xml.append(
-                f"<item><title>{xml_escape(title)}</title><link>{link}</link>"
+                f"<item><title>{xml_escape(title)}</title><link>{xml_escape(link)}</link>"
                 f"<description>{xml_escape(it.get('summary', '')[:200])}</description></item>"
             )
 
@@ -1575,7 +1575,7 @@ def _build_rss(diff: dict, generated_at: str) -> str:
             link = item.get("href", "https://csrc.nist.gov/")
             items_xml.append(
                 f"<item><title>{xml_escape('NIST ' + page_key + ': ' + (item.get('text') or '')[:60])}</title>"
-                f"<link>{link}</link>"
+                f"<link>{xml_escape(link)}</link>"
                 f"<description>New item on NIST CSRC {xml_escape(page_key)} page.</description></item>"
             )
 
@@ -1584,7 +1584,7 @@ def _build_rss(diff: dict, generated_at: str) -> str:
             link = item.get("href", "https://www.commoncriteriaportal.org/")
             items_xml.append(
                 f"<item><title>{xml_escape('CC Crypto: ' + (item.get('text') or page_key)[:80])}</title>"
-                f"<link>{link}</link>"
+                f"<link>{xml_escape(link)}</link>"
                 f"<description>New item on CC Crypto {xml_escape(page_key)} page.</description></item>"
             )
 
@@ -1720,8 +1720,23 @@ def render_dashboard(diff: dict, output_dir: str = "docs") -> None:
         "cc_crypto","nist","cc_portal","pcl_all","in_eval"
     ]}
 
-    # Render template
-    env = Environment(autoescape=False)
+    # Render template. autoescape=True so scraped/vendor-controlled strings
+    # (product names, RSS titles, hrefs) can't inject markup into the public
+    # dashboard. noindex_meta is the only trusted-HTML variable — marked | safe
+    # at its use site.
+    env = Environment(autoescape=True)
+
+    def _safe_url(u):
+        """Blank out hrefs that don't use a safe scheme. autoescape handles
+        metacharacters, but javascript:/data: URLs contain none and would
+        otherwise render as clickable. Applied via the |safe_url filter."""
+        u = ("" if u is None else str(u)).strip()
+        low = u.lower()
+        if low.startswith(("http://", "https://", "mailto:")) or u.startswith("/"):
+            return u
+        return ""
+
+    env.filters["safe_url"] = _safe_url
     tmpl = env.from_string(DASHBOARD_TEMPLATE)
     html = tmpl.render(
         diff            = diff,

--- a/emailer.py
+++ b/emailer.py
@@ -14,6 +14,7 @@ Features:
   - Generic webhook / MS Teams delivery via send_webhook_alert()
 - Plain-language change descriptions via _describe_change() (issue #17)
 """
+import html
 import json
 import logging
 import os
@@ -350,6 +351,31 @@ def send_webhook_alert(alerts: list[dict]) -> None:
 # Email HTML helpers
 # ---------------------------------------------------------------------------
 
+def _esc(s) -> str:
+    """HTML-escape a scraped/vendor-controlled value for safe embedding in
+    notification HTML. Neutralises markup injection (e.g. a product name or
+    RSS title containing <script> or "-breakout into an attribute)."""
+    return html.escape("" if s is None else str(s), quote=True)
+
+
+def _safe_url(u) -> str:
+    """Return an escaped URL only if it uses a safe scheme, else ''.
+    Blocks javascript:/data:/vbscript: hrefs that survive plain escaping
+    because they contain no HTML metacharacters."""
+    u = ("" if u is None else str(u)).strip()
+    low = u.lower()
+    if low.startswith(("http://", "https://", "mailto:")) or u.startswith("/"):
+        return html.escape(u, quote=True)
+    return ""
+
+
+def _link(url, title) -> str:
+    """Build an anchor from untrusted url+title, escaping both. Falls back to
+    escaped title text when the URL is missing or uses an unsafe scheme."""
+    safe = _safe_url(url)
+    return f'<a href="{safe}">{_esc(title)}</a>' if safe else _esc(title)
+
+
 def _row(label: str, content: str, color: str = "#22D3EE", bg: str = "#12102E") -> str:
     return (
         f'<tr style="border-bottom:1px solid #312E81">'
@@ -377,6 +403,7 @@ def _section(title: str, rows: list[str]) -> str:
 def build_email_html(weekly_diff: dict) -> str:
     now  = datetime.now(ET)
     date = now.strftime("%B %d, %Y")
+    date_str = date  # fix: alert branch referenced undefined date_str (latent NameError)
     parts: list[str] = []
 
     # ── Keyword alerts (top, sorted by tier) ──────────────────────────────
@@ -384,12 +411,12 @@ def build_email_html(weekly_diff: dict) -> str:
     if alerts:
         alert_rows = []
         for a in sorted(alerts, key=lambda x: (_alert_tier(x), alerts.index(x))):
-            kws    = ", ".join(a.get("matched_keywords", []))
-            title  = a.get("title", "")
-            detail = a.get("detail", "")
-            url    = a.get("url", "")
+            kws    = _esc(", ".join(a.get("matched_keywords", [])))
+            title  = _esc(a.get("title", ""))
+            detail = _esc(a.get("detail", ""))
+            url    = _safe_url(a.get("url", ""))
             kind   = a.get("kind", "")
-            src    = a.get("source", "ALERT")
+            src    = _esc(a.get("source", "ALERT"))
             tier   = _alert_tier(a)
             cisco_badge = (
                 '<span style="background:#3B82F6;color:#fff;padding:1px 6px;'
@@ -426,12 +453,12 @@ def build_email_html(weekly_diff: dict) -> str:
     pp   = weekly_diff.get("niap", {}).get("pps", {})
     rows: list[str] = []
     for p in pp.get("added", []):
-        rows.append(_row("NEW", f"<b>{p.get('pp_short_name','')}</b> - {p.get('pp_name','')}"))
+        rows.append(_row("NEW", f"<b>{_esc(p.get('pp_short_name',''))}</b> - {_esc(p.get('pp_name',''))}"))
     for p in pp.get("removed", []):
-        rows.append(_row("REMOVED", f"<b>{p.get('pp_short_name','')}</b>", "#F87171", "#1E1B4B"))
+        rows.append(_row("REMOVED", f"<b>{_esc(p.get('pp_short_name',''))}</b>", "#F87171", "#1E1B4B"))
     for p in pp.get("sunset_changes", []):
         rows.append(_row("SUNSET",
-            f"<b>{p.get('pp_short_name','')}</b> - Sunset: {p.get('new_sunset','')[:10]}",
+            f"<b>{_esc(p.get('pp_short_name',''))}</b> - Sunset: {_esc(p.get('new_sunset','')[:10])}",
             "#FBBF24", "#1E1B4B"))
     parts.append(_section("NIAP - Protection Profiles", rows))
 
@@ -439,9 +466,9 @@ def build_email_html(weekly_diff: dict) -> str:
     td   = weekly_diff.get("niap", {}).get("tds", {})
     rows = []
     for t in td.get("added", []):
-        rows.append(_row("NEW TD", f"<b>{t.get('identifier','')}</b> - {t.get('title','')}"))
+        rows.append(_row("NEW TD", f"<b>{_esc(t.get('identifier',''))}</b> - {_esc(t.get('title',''))}"))
     for t in td.get("removed", []):
-        rows.append(_row("REMOVED", f"<b>{t.get('identifier','')}</b>", "#F87171", "#1E1B4B"))
+        rows.append(_row("REMOVED", f"<b>{_esc(t.get('identifier',''))}</b>", "#F87171", "#1E1B4B"))
     parts.append(_section("NIAP - Technical Decisions", rows))
 
     # ── Cisco NDcPP ────────────────────────────────────────────────────────
@@ -449,11 +476,11 @@ def build_email_html(weekly_diff: dict) -> str:
     rows = []
     for p in cn.get("added", []):
         rows.append(_row("CERTIFIED",
-            f"<b>{p.get('product_name','')}</b> ({p.get('vendor_id_name','')})"))
+            f"<b>{_esc(p.get('product_name',''))}</b> ({_esc(p.get('vendor_id_name',''))})"))
     for p in cn.get("newly_archived", []):
-        rows.append(_row("ARCHIVED", f"<b>{p.get('product_name','')}</b>", "#FBBF24", "#1E1B4B"))
+        rows.append(_row("ARCHIVED", f"<b>{_esc(p.get('product_name',''))}</b>", "#FBBF24", "#1E1B4B"))
     for p in cn.get("removed", []):
-        rows.append(_row("REMOVED", f"<b>{p.get('product_name','')}</b>", "#F87171", "#1E1B4B"))
+        rows.append(_row("REMOVED", f"<b>{_esc(p.get('product_name',''))}</b>", "#F87171", "#1E1B4B"))
     parts.append(_section("Cisco NDcPP PCL Changes", rows))
 
     # ── NIAP announcements, events, and policy letters ─────────────────────
@@ -472,7 +499,7 @@ def build_email_html(weekly_diff: dict) -> str:
                     item.get("title") or item.get("policy_title")
                     or item.get("name") or f"NIAP {section.rstrip('s')}"
                 )
-                txt = f'<a href="{link}">{title}</a>' if link else title
+                txt = _link(link, title)
                 rows.append(_row(f"{kind.upper()} {category}", txt, "#60A5FA", "#12102E"))
     parts.append(_section("NIAP - Announcements, Events, and Policies", rows))
 
@@ -483,7 +510,7 @@ def build_email_html(weekly_diff: dict) -> str:
         for item in items[:5]:
             link  = item.get("link", "")
             title = item.get("title", "")
-            txt   = f'<a href="{link}">{title}</a>' if link else title
+            txt   = _link(link, title)
             rows.append(_row(lab[:18], txt, "#60A5FA", "#12102E"))
     parts.append(_section("CCTL Lab Intel", rows))
 
@@ -496,9 +523,9 @@ def build_email_html(weekly_diff: dict) -> str:
             new_lm = change.get("new_last_modified", "")
             url    = change.get("url", "")
             detail = f"Last-Modified: {old_lm or '—'} → {new_lm or '—'}"
-            txt    = f'<a href="{url}">{cp_name}</a>' if url else cp_name
+            txt    = _link(url, cp_name)
             rows.append(_row("CP UPDATE",
-                f"<b>{txt}</b><br><small>{detail}</small>", "#FBBF24", "#12102E"))
+                f"<b>{txt}</b><br><small>{_esc(detail)}</small>", "#FBBF24", "#12102E"))
     _csfc_page_urls = {
         "apl":           config.CSFC_PRODUCT_LIST_URL,
         "home":          config.CSFC_BASE + "/Resources/Commercial-Solutions-for-Classified-Program/",
@@ -509,13 +536,13 @@ def build_email_html(weekly_diff: dict) -> str:
         for item in page_diff.get("added", [])[:3]:
             page_url = item.get("href") or item.get("link") or _csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL)
             label    = "APL" if page_key == "apl" else page_key[:8]
-            txt      = f'<a href="{page_url}">{item.get("text", "")[:100]}</a>' if page_url else item.get("text", "")[:120]
+            txt      = _link(page_url, item.get("text", "")[:120])
             rows.append(_row(f"NSA:{label}", txt, "#60A5FA", "#12102E"))
     for feed_name, items in csfc.get("feeds", {}).items():
         for item in items[:3]:
             link  = item.get("link", "")
             title = item.get("title", "")
-            txt   = f'<a href="{link}">{title}</a>' if link else title
+            txt   = _link(link, title)
             rows.append(_row("ADVISORY", txt, "#60A5FA", "#12102E"))
     parts.append(_section("CSfC — Capability Packages & APL", rows))
 
@@ -532,7 +559,7 @@ def build_email_html(weekly_diff: dict) -> str:
             continue
         for item in page_diff.get("added", [])[:5]:
             page_url = item.get("href") or _cc_urls.get(page_key, "https://www.commoncriteriaportal.org/cc/index.cfm")
-            txt = f'<a href="{page_url}">{item.get("text","")[:100]}</a>' if page_url else item.get("text","")[:120]
+            txt = _link(page_url, item.get("text", "")[:120])
             label = "CC PUB" if page_key == "publications" else f"CC:{page_key[:6]}"
             rows.append(_row(label, txt, "#60A5FA", "#12102E"))
     parts.append(_section("CC Crypto Catalog & Working Group", rows))
@@ -550,7 +577,7 @@ def build_email_html(weekly_diff: dict) -> str:
         label = f"{name}" + (f" ({vendor})" if vendor else "")
         detail = f"Status: {status}" if status else "New to MIP list"
         rows.append(_row("CMVP NEW",
-            f'<a href="{_cmvp_url}">{label}</a><br><small>{detail}</small>',
+            f'<a href="{_cmvp_url}">{_esc(label)}</a><br><small>{_esc(detail)}</small>',
             "#22D3EE", "#12102E"))
     for item in cmvp_mip.get("status_changes", [])[:5]:
         name = item.get("Module Name") or item.get("name") or item.get("text", "")[:80]
@@ -558,7 +585,7 @@ def build_email_html(weekly_diff: dict) -> str:
         label = f"{name}" + (f" ({vendor})" if vendor else "")
         detail = f"{item.get('old_status','?')} → {item.get('new_status','?')}"
         rows.append(_row("CMVP STATUS",
-            f'<a href="{_cmvp_url}">{label}</a><br><small>{detail}</small>',
+            f'<a href="{_cmvp_url}">{_esc(label)}</a><br><small>{_esc(detail)}</small>',
             "#FBBF24", "#12102E"))
     _nist_page_urls = {
         "news": "https://csrc.nist.gov/news",
@@ -574,45 +601,44 @@ def build_email_html(weekly_diff: dict) -> str:
             continue
         for item in page_diff.get("added", [])[:3]:
             page_url = item.get("href") or _nist_page_urls.get(page_key, "https://csrc.nist.gov/")
-            txt = f'<a href="{page_url}">{item.get("text","")[:100]}</a>' if page_url else item.get("text","")[:120]
+            txt = _link(page_url, item.get("text", "")[:120])
             rows.append(_row(f"NIST:{page_key[:7]}", txt, "#22D3EE", "#12102E"))
     for feed_name, items in nist.get("feeds", {}).items():
         for item in items[:5]:
             link = item.get("link", "")
             title = item.get("title", "")
-            txt = f'<a href="{link}">{title}</a>' if link else title
+            txt = _link(link, title)
             rows.append(_row("NIST FEED", txt, "#22D3EE", "#12102E"))
     parts.append(_section("NIST CSRC — Standards, CMVP & PQC", rows))
 
-    body = (
-        '<div style="background:#12102E;color:#FB923C;padding:14px 18px;border:1px solid #C026D3;'
-        'border-radius:6px;margin-bottom:8px">'
-        f'<b style="font-size:1rem">&#9888; {len(alerts)} KEYWORD ALERT(S) DETECTED</b>'
-        f'<p style="margin:4px 0 0;font-size:0.85rem;opacity:0.85">'
-        f'{date_str} \u2014 immediate notification</p>'
-        f'{tier_note}'
-        '</div>'
-        + _section("Keyword Matches \u2014 Source, Detail & Links", rows)
-        + dashboard_link
+    # Assemble the weekly digest. The alert section (if any) is already the
+    # first entry in `parts`; the previous tail here referenced undefined
+    # locals (date_str/tier_note/dashboard_link/subject) copied from the
+    # immediate-alert sender and never returned, so the weekly email was
+    # effectively dead. Build the outer shell and RETURN the HTML;
+    # send_weekly_email() is responsible for sending.
+    dashboard_link = (
+        '<p style="margin-top:20px"><a '
+        'href="https://kr15tyk.github.io/CC-pulse/cc_dashboard.html" '
+        'style="color:#60A5FA">View full dashboard \u2192</a></p>'
     )
-
     generated = datetime.now(ET).strftime("%Y-%m-%d %H:%M ET")
-    html = (
+    return (
         '<html><body style="font-family:-apple-system,BlinkMacSystemFont,sans-serif;'
         'max-width:720px;margin:0 auto;color:#E0E7FF">'
         '<div style="background:#0B0F1A;color:#FB923C;padding:20px 28px;border-bottom:2px solid #C026D3">'
-        '<h1 style="margin:0;font-size:1.4rem;color:#FB923C;font-family:Courier New,monospace;letter-spacing:0.08em">// CC Pulse &#8212; Immediate Alert</h1>'
-        f'<p style="margin:4px 0 0;opacity:0.75;font-size:0.85rem">{date_str}</p>'
+        '<h1 style="margin:0;font-size:1.4rem;color:#FB923C;font-family:Courier New,monospace;letter-spacing:0.08em">// CC Pulse &#8212; Weekly Digest</h1>'
+        f'<p style="margin:4px 0 0;opacity:0.75;font-size:0.85rem">{date}</p>'
         '</div>'
         '<div style="background:#E0E7FF;padding:20px 28px;border:1px solid #3730A3;'
         'border-top:none;border-radius:0 0 8px 8px">'
-        f'{body}'
-        '<hr style="margin-top:28px;border:none;border-top:1px solid #312E81">'
+        + "".join(parts)
+        + dashboard_link
+        + '<hr style="margin-top:28px;border:none;border-top:1px solid #312E81">'
         f'<p style="color:#6366F1;font-size:0.75rem;margin-top:12px">'
-        f'CC Pulse automated monitoring \u2014 immediate alert<br>Generated {generated}</p>'
+        f'CC Pulse automated monitoring \u2014 weekly digest<br>Generated {generated}</p>'
         '</div></body></html>'
     )
-    _send_email(subject, html)
 
 
 # ---------------------------------------------------------------------------
@@ -666,12 +692,12 @@ def send_alert_email(alerts: list[dict]) -> None:
     )
     rows = []
     for a in sorted(alerts, key=lambda x: (_alert_tier(x), alerts.index(x))):
-        kws = ", ".join(a.get("matched_keywords", []))
-        title = a.get("title", "")
-        detail = a.get("detail", "")
-        url = a.get("url", "")
+        kws = _esc(", ".join(a.get("matched_keywords", [])))
+        title = _esc(a.get("title", ""))
+        detail = _esc(a.get("detail", ""))
+        url = _safe_url(a.get("url", ""))
         kind = a.get("kind", "")
-        src = a.get("source", "ALERT")
+        src = _esc(a.get("source", "ALERT"))
         tier = _alert_tier(a)
         cisco_badge = (
             '<span style="background:#3B82F6;color:#fff;padding:1px 6px;'
@@ -1123,17 +1149,17 @@ def send_cisco_cert_email(new_certs: list[dict]) -> None:
     cert_blocks = []
     for p in new_certs:
         pid         = p.get("product_id", "")
-        name        = p.get("product_name", "Unknown product")
-        vendor      = p.get("vendor_id_name", "Cisco")
-        cert_date   = (p.get("certification_date") or "")[:10]
-        sunset_date = (p.get("sunset_date") or "")[:10]
-        lab         = p.get("assigned_lab_name", "N/A")
-        country     = p.get("submitting_country_id_name", "N/A")
+        name        = _esc(p.get("product_name", "Unknown product"))
+        vendor      = _esc(p.get("vendor_id_name", "Cisco"))
+        cert_date   = _esc((p.get("certification_date") or "")[:10])
+        sunset_date = _esc((p.get("sunset_date") or "")[:10])
+        lab         = _esc(p.get("assigned_lab_name", "N/A"))
+        country     = _esc(p.get("submitting_country_id_name", "N/A"))
         pps         = p.get("protection_profiles", [])
-        pp_names    = ", ".join(
+        pp_names    = _esc(", ".join(
             pp.get("pp_short_name", "") for pp in pps if pp.get("pp_short_name")
-        ) or "N/A"
-        niap_url    = (
+        ) or "N/A")
+        niap_url    = _safe_url(
             f"https://www.niap-ccevs.org/products/{pid}"
             if pid else "https://www.niap-ccevs.org/products"
         )


### PR DESCRIPTION
## Output escaping (stored XSS) + weekly digest fix

### Why
Two problems in the output layer, coupled because both live inside `build_email_html`.

**Stored XSS.** `dashboard.py` rendered its Jinja environment with `autoescape=False` and interpolated scraped values (RSS titles, product/vendor names, hrefs) raw into the published dashboard on the github.io origin. Same pattern across every f-string-built anchor in `emailer.py`. Verified: an `<img src=x onerror=...>` title and a `javascript:` href both survive verbatim into rendered output. Sources are scraped (ENISA, atsec, CC Portal, DISA), so vendor/product names and feed fields are attacker-influenceable.

**Weekly digest is dead.** `build_email_html` references `date_str`, `tier_note`, `dashboard_link`, `subject` that are never defined in its scope (copy-pasted from the immediate-alert sender), double-calls `_send_email`, and never returns. It `NameError`s on entry every run. No test exercised the weekly path, so the suite stayed green over a broken run mode.

### What changed
- `dashboard.py`: `autoescape=True`; `noindex_meta` marked `| safe` (only intentional-HTML var); added a `safe_url` Jinja filter (blanks non-http(s)/mailto/relative schemes) applied to all 17 dynamic href sites — autoescape alone doesn't stop `javascript:` hrefs. Normalized 5 RSS `<link>` fields that were unescaped while siblings used `xml_escape`.
- `emailer.py`: added `_esc` / `_safe_url` / `_link` helpers; escape scraped fields at assignment so every downstream interpolation is covered. Reconstructed `build_email_html` to assemble `parts` and **return** the digest HTML (the alert section is already the first entry in `parts`, so the pasted banner was redundant).

### Verification
Injection payloads re-tested against live render — neutralized in both dashboard and email. Weekly digest now builds without `NameError`. Full suite green.

### Reviewer note
The weekly digest layout was reconstructed from surrounding code intent — please confirm the rendered digest matches what you actually want sent.
