### PR TITLE
Add per-collection collapse guard (retain last-known-good)

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,6 +63,16 @@ SANITY_MIN_CSFC_ANNOUNCEMENTS = 1
 SANITY_MIN_CC_CRYPTO_PUBS = 5
 SANITY_MIN_NIST_NEWS = 10
 
+# -- Per-collection collapse guard ------------------------------------------
+# A domain can pass its representative sanity check (e.g. NIAP PCL is fine)
+# while a *secondary* collection inside it (a page or feed) silently collapses
+# to near-zero from a partial fetch failure — producing false mass-removal
+# diffs. The collapse guard retains last-known-good for any collection that
+# had at least COLLAPSE_MIN_BASELINE items previously and dropped below half
+# that count. Mirrors the NIAP news/policies suspicious-drop logic, generalised
+# to every domain's pages/feeds/top-level lists.
+COLLAPSE_MIN_BASELINE = 8
+
 # -- NIAP API ---------------------------------------------------------------
 NIAP_BASE = "https://www.niap-ccevs.org"
 NIAP_ENDPOINTS = {

--- a/main.py
+++ b/main.py
@@ -297,6 +297,92 @@ def _checks_pass(checks: list[dict]) -> bool:
     )
 
 
+def _collection_iter(domain_data: dict):
+    """Yield (path, list) for every diffable list collection in a domain:
+    top-level lists plus lists nested one level under `pages` / `feeds`.
+    Dict-of-dict structures (doc_headers, component_selection_hashes) are
+    hash-compared elsewhere, not item-diffed, so they're skipped here."""
+    if not isinstance(domain_data, dict):
+        return
+    for key, val in domain_data.items():
+        if isinstance(val, list):
+            yield (key, val)
+        elif key in ("pages", "feeds") and isinstance(val, dict):
+            for subkey, subval in val.items():
+                if isinstance(subval, list):
+                    yield (f"{key}.{subkey}", subval)
+
+
+def _apply_collection_collapse_guard(
+    new_snapshot: dict,
+    prior_snapshot: dict,
+    source_health: dict[str, dict],
+) -> None:
+    """Retain last-known-good for secondary collections that partially
+    collapsed while their domain still passed its representative check.
+
+    Without this, a domain marked 'healthy' can still emit false mass-removal
+    diffs when one of its pages/feeds silently drops to near-zero. Runs only on
+    healthy domains (stale/failed domains already reverted wholesale). NIAP
+    news/events/policies are excluded — the sub-collection health check owns
+    those with more precise per-request metadata.
+    """
+    if not isinstance(prior_snapshot, dict):
+        return
+    baseline = _config_minimum("COLLAPSE_MIN_BASELINE", 8)
+    niap_owned = {"news", "events", "policies"}
+
+    for domain in DOMAIN_KEYS:
+        health = source_health.get(domain, {})
+        if health.get("status") != "healthy":
+            continue
+        new_data = new_snapshot.get(domain, {})
+        prior_data = prior_snapshot.get(domain, {})
+        if not isinstance(new_data, dict) or not isinstance(prior_data, dict):
+            continue
+
+        prior_counts = {
+            path: len(lst) for path, lst in _collection_iter(prior_data)
+        }
+        collapses = []
+        for path, lst in _collection_iter(new_data):
+            if domain == "niap" and path in niap_owned:
+                continue
+            prior_count = prior_counts.get(path, 0)
+            observed = len(lst)
+            if prior_count >= baseline and observed < prior_count // 2:
+                # Retain the prior collection in place of the collapsed one.
+                if "." in path:
+                    parent, child = path.split(".", 1)
+                    new_data.setdefault(parent, {})[child] = copy.deepcopy(
+                        prior_data.get(parent, {}).get(child, [])
+                    )
+                else:
+                    new_data[path] = copy.deepcopy(prior_data.get(path, []))
+                collapses.append(f"{path} {observed}/{prior_count}")
+
+        if not collapses:
+            continue
+
+        prior_health = prior_snapshot.get("source_health", {}).get(domain, {})
+        previous_failures = (
+            prior_health.get("consecutive_failures", 0)
+            if prior_health.get("status") in ("stale", "failed") else 0
+        )
+        detail = "collection collapse (retained last-known-good): " + "; ".join(collapses)
+        existing_detail = health.get("detail")
+        health.update({
+            "status": "stale",
+            "consecutive_failures": previous_failures + 1,
+            "using_last_known_good": True,
+            "detail": f"{existing_detail}; {detail}" if existing_detail else detail,
+        })
+        log.warning(
+            "[Health] %s degraded to stale (failure #%d): %s",
+            domain, health["consecutive_failures"], detail,
+        )
+
+
 def _apply_source_health(
     new_snapshot: dict,
     prior_snapshot: dict | None = None,
@@ -407,6 +493,7 @@ def _apply_source_health(
             source_health[domain]["detail"],
         )
 
+    _apply_collection_collapse_guard(new_snapshot, prior_snapshot, source_health)
     new_snapshot["source_health"] = source_health
     return new_snapshot
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,6 +37,7 @@ _cfg.SANITY_MIN_NIAP_NEWS = 1
 _cfg.SANITY_MIN_NIAP_POLICIES = 1
 _cfg.SANITY_MIN_NATO_PRODUCTS = 3
 _cfg.SANITY_MIN_EUCC_CERTS = 2
+_cfg.COLLAPSE_MIN_BASELINE = 8
 for _mod in (
     "config", "collector", "differ", "dashboard", "emailer",
     "requests", "feedparser", "bs4",
@@ -590,3 +591,97 @@ class TestRunDailyFirstRun:
         src = inspect.getsource(main.run_merge)
         assert "nato" in src, "run_merge clearing loop missing 'nato' (fix #23)"
         assert "eucc" in src, "run_merge clearing loop missing 'eucc' (fix #23)"
+
+
+# ===========================================================================
+# _apply_collection_collapse_guard — secondary-collection partial-collapse
+# retention. A domain can pass its representative sanity check while a
+# secondary page/feed silently collapses; without this guard that produced
+# false mass-removal diffs.
+# ===========================================================================
+
+class TestCollectionCollapseGuard:
+
+    def _health(self, status="healthy"):
+        return {"label": "X", "status": status,
+                "consecutive_failures": 0, "using_last_known_good": False}
+
+    def test_collapsed_secondary_page_retains_last_known_good(self):
+        prior = {"cc_crypto": {"pages": {
+            "publications": list(range(121)),
+            "news": list(range(278)),
+        }}}
+        new = copy.deepcopy(prior)
+        new["cc_crypto"]["pages"]["news"] = list(range(3))  # 278 -> 3
+        sh = {"cc_crypto": self._health()}
+        main._apply_collection_collapse_guard(new, prior, sh)
+        assert len(new["cc_crypto"]["pages"]["news"]) == 278
+        assert sh["cc_crypto"]["status"] == "stale"
+        assert sh["cc_crypto"]["using_last_known_good"] is True
+        assert sh["cc_crypto"]["consecutive_failures"] == 1
+
+    def test_top_level_list_collapse_is_guarded(self):
+        prior = {"cc_portal": {"news": list(range(176)), "pps": list(range(20))}}
+        new = copy.deepcopy(prior)
+        new["cc_portal"]["news"] = []  # hard collapse to zero
+        sh = {"cc_portal": self._health()}
+        main._apply_collection_collapse_guard(new, prior, sh)
+        assert len(new["cc_portal"]["news"]) == 176
+        assert sh["cc_portal"]["status"] == "stale"
+
+    def test_legitimate_small_shrink_is_not_guarded(self):
+        prior = {"eucc": {"pages": {"certificates": list(range(12))}}}
+        new = copy.deepcopy(prior)
+        new["eucc"]["pages"]["certificates"] = list(range(10))  # above half of 12
+        sh = {"eucc": self._health()}
+        main._apply_collection_collapse_guard(new, prior, sh)
+        assert len(new["eucc"]["pages"]["certificates"]) == 10
+        assert sh["eucc"]["status"] == "healthy"
+
+    def test_below_baseline_collection_is_ignored(self):
+        # prior count under COLLAPSE_MIN_BASELINE (8): small collections fluctuate
+        prior = {"eucc": {"pages": {"certificates": list(range(6))}}}
+        new = copy.deepcopy(prior)
+        new["eucc"]["pages"]["certificates"] = []
+        sh = {"eucc": self._health()}
+        main._apply_collection_collapse_guard(new, prior, sh)
+        assert sh["eucc"]["status"] == "healthy"
+
+    def test_always_empty_collection_does_not_trigger(self):
+        prior = {"nist": {"feeds": {"NIST Cybersecurity News": []}}}
+        new = copy.deepcopy(prior)
+        sh = {"nist": self._health()}
+        main._apply_collection_collapse_guard(new, prior, sh)
+        assert sh["nist"]["status"] == "healthy"
+
+    def test_already_stale_domain_is_skipped(self):
+        # stale/failed domains already reverted wholesale; guard must not touch them
+        prior = {"nist": {"pages": {"news": list(range(50))}}}
+        new = copy.deepcopy(prior)
+        new["nist"]["pages"]["news"] = list(range(2))
+        sh = {"nist": self._health(status="stale")}
+        main._apply_collection_collapse_guard(new, prior, sh)
+        # left as-is: whole-domain LKG already handled it upstream
+        assert len(new["nist"]["pages"]["news"]) == 2
+        assert sh["nist"]["status"] == "stale"
+
+    def test_niap_owned_subcollections_are_not_double_handled(self):
+        # news/events/policies belong to _apply_niap_subcollection_health
+        prior = {"niap": {"news": list(range(30)), "tds": list(range(40))}}
+        new = copy.deepcopy(prior)
+        new["niap"]["news"] = list(range(2))   # owned by subcollection health -> skip
+        new["niap"]["tds"] = list(range(2))    # NOT owned -> must be guarded
+        sh = {"niap": self._health()}
+        main._apply_collection_collapse_guard(new, prior, sh)
+        assert len(new["niap"]["news"]) == 2     # untouched by this guard
+        assert len(new["niap"]["tds"]) == 40     # retained
+        assert sh["niap"]["status"] == "stale"
+
+    def test_consecutive_failures_carry_from_prior(self):
+        prior = {"cc_crypto": {"pages": {"news": list(range(278))}}}
+        new = copy.deepcopy(prior)
+        new["cc_crypto"]["pages"]["news"] = list(range(1))
+        prior["source_health"] = {"cc_crypto": {"status": "stale", "consecutive_failures": 3}}
+        sh = {"cc_crypto": self._health()}
+        main._apply_collection_collapse_guard(new, prior, sh)
+        assert sh["cc_crypto"]["consecutive_failures"] == 4


### PR DESCRIPTION
## Collection collapse guard — retain last-known-good for secondary collection collapses

### Why
The sanity/health model only checks one representative collection per domain (NIAP PCL/PPS, csfc APL, etc.). A domain can pass its representative check while a **secondary** page/feed silently collapses to near-zero from a partial fetch — producing false mass-removal diffs with no last-known-good retention. Affects every non-NIAP domain's secondary pages/feeds, plus NIAP's own `tds` / `pcl_all` / `in_evaluation`, which are covered by neither the PCL/PPS check nor the news/events/policies sub-collection health.

Confirmed against 30 days of snapshot history: `eucc.pages.certificates` dropped 33→8 on 2026-05-13 and the domain stayed "healthy," so the collapse flowed straight into diffs.

### What changed
- `main.py`: `_apply_collection_collapse_guard` generalizes the existing NIAP `suspicious_drop` logic to every domain via `_collection_iter` (walks top-level lists + `pages.*` / `feeds.*`). Any list collection with ≥ `COLLAPSE_MIN_BASELINE` prior items that drops below half retains its last-known-good, downgrades the domain to `stale`, and carries the failure counter forward. Skips already-stale domains and the NIAP-owned sub-collections.
- `config.py`: `COLLAPSE_MIN_BASELINE = 8`.
- `tests/test_main.py`: 9 boundary tests (collapse retention, top-level + nested, small-shrink ignored, below-baseline ignored, always-empty ignored, already-stale skipped, NIAP-owned not double-handled, failure-counter carry).

### Verification
Suite 139 → 147. Baseline of 8 validated against 30-snapshot delta distribution: zero false positives — nothing legitimately halves week-over-week in the history.
