### PR TITLE
Fix ENISA EUCC certificate scrape — parse Drupal 11 card layout

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -839,8 +839,61 @@ def collect_nato() -> dict:
 
 
 # ── EUCC / ENISA ─────────────────────────────────────────────────────────────
-def _scrape_eucc_page(path: str) -> list:
-    """Scrape a single ENISA EUCC page and return a list of text/link items."""
+def _parse_eucc_cards(content) -> list:
+    """Parse ENISA EUCC certificate cards (Drupal 11 ``ecl-card`` layout).
+
+    Each certificate renders as::
+
+        <article class="ecl-card">
+          <time datetime="...">16 October 2025</time>
+          <div class="ecl-content-block__title"><a href="...">EUCC-3090-...</a></div>
+          <div class="ecl-content-block__description">The product evaluated is ...</div>
+          <dd class="ecl-description-list__definition">(UE) 2024/482 - EUCC</dd>
+        </article>
+
+    The certificate identifier is the EUCC number; the product/vendor name lives
+    in the description text, so ``text`` folds id + date + description together to
+    keep the existing Cisco keyword filter working. Returns ``[]`` when no cards
+    are present so the caller falls back to the table / generic scrape.
+    """
+    items = []
+    for card in content.find_all("article", class_="ecl-card"):
+        title_tag = card.find(class_="ecl-content-block__title")
+        link_tag = title_tag.find("a") if title_tag else None
+        cert_id = link_tag.get_text(strip=True) if link_tag else ""
+        href = link_tag["href"] if link_tag and link_tag.get("href") else ""
+        if href and not href.startswith("http"):
+            href = config.EUCC_BASE + href
+        desc_tag = card.find(class_="ecl-content-block__description")
+        desc = desc_tag.get_text(" ", strip=True) if desc_tag else ""
+        # ENISA descriptions contain &nbsp; (\xa0); normalize to plain spaces and
+        # collapse runs so stored text is stable and diffs don't churn on whitespace.
+        desc = " ".join(desc.replace("\xa0", " ").split())
+        time_tag = card.find("time")
+        cert_date = time_tag.get("datetime", "") if time_tag else ""
+        date_text = time_tag.get_text(strip=True) if time_tag else ""
+        if not cert_id and not desc:
+            continue
+        items.append({
+            "name": cert_id,
+            "text": f"{cert_id} | {date_text} | {desc}"[:400],
+            "href": href,
+            "cert_date": cert_date,
+            "description": desc[:400],
+        })
+    return items
+
+
+def _scrape_eucc_page(path: str, page_key: str = "") -> list:
+    """Scrape a single ENISA EUCC page and return a list of text/link items.
+
+    The certificates page is cards-only: if the ``ecl-card`` parser returns
+    nothing we return empty rather than falling through to the generic text
+    scrape. That generic scrape is what silently produced garbage (bare dates,
+    page chrome) for weeks when ENISA moved off a <table> — a hard empty makes
+    the sanity floor / collapse guard fire instead of masking the break.
+    Other pages (e.g. requirements) still use table + generic fallback.
+    """
     url = config.EUCC_BASE + path
     soup = get_html(url)
     if not soup:
@@ -852,7 +905,14 @@ def _scrape_eucc_page(path: str) -> list:
         or soup.find("div", {"class": "content"})
         or soup
     )
-    # Try table layout first (certificates page)
+    # Certificates page: Drupal 11 ecl-card grid, cards-or-empty (no fallback).
+    if page_key == "certificates":
+        return _parse_eucc_cards(content)
+    # Other pages: try cards, then table, then generic text scrape.
+    cards = _parse_eucc_cards(content)
+    if cards:
+        return cards
+    # Try table layout next (legacy / other pages)
     table = content.find("table")
     if table:
         headers = [th.get_text(strip=True).lower() for th in table.find_all("th")]
@@ -911,7 +971,7 @@ def collect_eucc() -> dict:
     }
     for page_key, path in config.EUCC_PAGES.items():
         log.info("  [EUCC] Scraping page: %s (%s)...", page_key, path)
-        data["pages"][page_key] = _scrape_eucc_page(path)
+        data["pages"][page_key] = _scrape_eucc_page(path, page_key)
         log.info("  -> %d items", len(data["pages"][page_key]))
     # Extract Cisco-specific certificates
     certs = data["pages"].get("certificates", [])

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -42,6 +42,7 @@ _cfg.NATO_NIAPCL_PAGES = {
 }
 _cfg.NATO_CISCO_KEYWORDS = ["cisco"]
 _cfg.NIST_CSRC_BASE = "https://csrc.nist.gov"
+_cfg.EUCC_BASE = "https://certification.enisa.europa.eu"
 sys.modules["config"] = _cfg
 # Also stub heavy deps
 for _mod in ("requests", "feedparser", "bs4", "lxml"):
@@ -547,3 +548,91 @@ class TestScrapeCsfcAnnouncements:
             "text": "5/20/25 | New CSfC guidance has been published",
             "href": "",
         }]
+
+
+class TestEuccCardParser:
+    """ENISA moved to a Drupal 11 ecl-card grid (~2026-05); the old table/generic
+    scrape silently produced garbage. These tests use real BeautifulSoup to
+    exercise the actual selectors, not mocks."""
+
+    @staticmethod
+    def _soup(html):
+        import sys
+        import importlib
+        stub = sys.modules.pop("bs4", None)
+        try:
+            bs4 = importlib.import_module("bs4")
+            return bs4.BeautifulSoup(html, "html.parser")
+        finally:
+            if stub is not None:
+                sys.modules["bs4"] = stub
+
+    CARD = (
+        '<article class="ecl-card"><div class="ecl-card__body"><div class="ecl-content-block">'
+        '<div class="ecl-content-block__primary-meta-container"><div class="ecl-content-block__primary-meta-item">'
+        '<time datetime="{dt}T12:00:00Z">{label}</time></div></div>'
+        '<div class="ecl-content-block__title"><a href="/certificates/{cid_l}_en" '
+        'class="ecl-link" data-ecl-title-link>{cid}</a></div>'
+        '<div class="ecl-content-block__description">{desc}</div>'
+        '<div class="ecl-content-block__list-container"><dl class="ecl-description-list">'
+        '<dt class="ecl-description-list__term">Certification Scheme</dt>'
+        '<dd class="ecl-description-list__definition">(UE) 2024/482 - EUCC</dd></dl></div>'
+        '</div></div></article>'
+    )
+
+    def _page(self, cards):
+        body = "".join(
+            self.CARD.format(dt=dt, label=label, cid=cid, cid_l=cid.lower(), desc=desc)
+            for dt, label, cid, desc in cards
+        )
+        return self._soup(f'<main>{body}</main>').find("main")
+
+    def test_parses_cards_into_records(self):
+        content = self._page([
+            ("2025-10-16", "16 October 2025", "EUCC-3090-2025-0000000005-00002",
+             "The product evaluated is a microcontroller developed by SAMSUNG."),
+        ])
+        items = collector._parse_eucc_cards(content)
+        assert len(items) == 1
+        rec = items[0]
+        assert rec["name"] == "EUCC-3090-2025-0000000005-00002"
+        assert rec["cert_date"] == "2025-10-16T12:00:00Z"
+        assert rec["href"] == (
+            "https://certification.enisa.europa.eu"
+            "/certificates/eucc-3090-2025-0000000005-00002_en"
+        )
+        assert "SAMSUNG" in rec["description"]
+
+    def test_nbsp_is_normalized(self):
+        content = self._page([
+            ("2025-12-03", "3 December 2025", "EUCC-3110-2025-2500098-01-00000",
+             "The Cisco Nexus 9K Series.&nbsp;Cisco NX-OS is proprietary.&nbsp;"),
+        ])
+        desc = collector._parse_eucc_cards(content)[0]["description"]
+        assert "\xa0" not in desc
+        assert "  " not in desc
+
+    def test_cisco_content_survives_for_keyword_filter(self):
+        content = self._page([
+            ("2025-09-14", "14 September 2025", "EUCC-3110-2025-0002500093-00001",
+             "The certified product is Cisco Intersight Virtual Appliance."),
+        ])
+        rec = collector._parse_eucc_cards(content)[0]
+        assert "cisco" in (rec["name"] + rec["text"]).lower()
+
+    def test_no_cards_returns_empty(self):
+        content = self._soup(
+            "<main><p>random 39 date fragments 14 November 2025</p></main>"
+        ).find("main")
+        assert collector._parse_eucc_cards(content) == []
+
+    def test_certificates_page_does_not_fall_back_to_generic(self):
+        # A page with no cards but plenty of long <p>/<li> text must return empty
+        # for the certificates key, so the sanity floor fires instead of garbage.
+        soup = self._soup(
+            "<main><p>" + "EU Cybersecurity Certificates boilerplate " * 5 + "</p>"
+            "<li>14 November 2025</li><li>17 December 2025</li></main>"
+        )
+        with patch.object(collector, "get_html", return_value=soup):
+            items = collector._scrape_eucc_page("/certificates_en", "certificates")
+        assert items == []


### PR DESCRIPTION
## Fix ENISA EUCC certificate scrape — parse Drupal 11 card layout (closes #41)

### Why
ENISA moved the certificates page off a `<table>` to a Drupal 11 `ecl-card` grid around 2026-05-13. `_scrape_eucc_page` tried a table, found none, and silently fell through to a generic "scrape every `<p>/<li>/<td>` over 15 chars" fallback — which emitted page boilerplate and bare date strings ("14 November 2025") as if they were certificates. The count sat at a stable 8–9, so no volume alarm fired; eucc diffs have been garbage since. See #41.

### What changed
- New `_parse_eucc_cards()` targets the real structure: `article.ecl-card` → `time[datetime]` (date), `.ecl-content-block__title a` (EUCC id + href), `.ecl-content-block__description` (product/vendor text). The cert identifier is the EUCC number; the product name lives in the description, so `text` folds id + date + description together to keep the existing Cisco keyword filter working.
- `&nbsp;` (`\xa0`) is normalized to plain spaces and runs collapsed, so stored text is stable and diffs don't churn on whitespace.
- The **certificates page is now cards-or-empty**: if the card parser returns nothing, `_scrape_eucc_page` returns `[]` rather than falling through to the generic scrape. A hard empty makes the sanity floor / collapse guard fire loudly instead of masking a structural break for weeks. Other pages (e.g. requirements) keep the table + generic fallback.

### Verification
5 new tests in `TestEuccCardParser` use real BeautifulSoup (not mocks) to exercise the actual selectors: record parsing, `&nbsp;` normalization, Cisco content survival, empty-on-no-cards, and — the key one — that the certificates page does **not** fall back to generic scraping. Full suite: 152 passed.

### Local check against the live page
After merge, confirm the collector returns the real count, not 8–9:
```
python -c "import collector; print(len(collector._scrape_eucc_page('/certificates_en','certificates')))"
```
Expect ~39 (matches the page's "(39)" header).

### Note
Last-known-good for eucc is now weeks stale, so the guard fails safe but does not restore history; the first good run after this lands repopulates it.
