### PR TITLE
Docs: sync with merged changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The tool detects additions, revisions, status changes, removals, and document re
 
 ## Quick start
 
+Requires Python 3.10 or newer (the code uses `X | None` type syntax). On macOS the system `python3` is 3.9; install a newer interpreter (e.g. `brew install python@3.12`) and build the venv from it.
+
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,6 +2,8 @@
 
 ## Setup
 
+Requires Python 3.10 or newer. The macOS system `python3` is 3.9 and will fail at import on the `X | None` type syntax; build the venv from a newer interpreter (e.g. `brew install python@3.12`).
+
 ```bash
 python3 -m venv .venv
 . .venv/bin/activate

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -28,9 +28,11 @@ Each source domain is validated before diffing. NIAP announcements, events, and 
 
 When a collection fails, is incomplete, or drops suspiciously:
 
-1. The affected domain or NIAP subcollection keeps its last-known-good records.
-2. Healthy domains continue normally.
+1. The affected collection keeps its last-known-good records. This applies at three levels: a whole domain that fails its representative check, a NIAP subcollection (announcements, events, policies) validated independently, and any secondary collection — any domain's `pages`/`feeds`/top-level list — that collapses to below half its prior size from a baseline of at least `COLLAPSE_MIN_BASELINE` items. The last catches partial-fetch collapses in collections that aren't the domain's representative check (for example a NIAP `tds`/`pcl_all`/`in_evaluation` list, or an EUCC/NIST/CSfC secondary page/feed) which would otherwise pass domain-level health while emitting false removals.
+2. Healthy domains continue normally; a collection collapse downgrades only the affected domain to `stale`, carrying its failure counter forward.
 3. The degraded state is recorded in `source_health` metadata and workflow logs.
 4. No false mass-removal diff is generated.
+
+A collapse guard covers *volume* — a collection dropping to near-zero. It does not detect a small-but-corrupt payload that stays above the volume threshold; that class of failure is caught, where it is caught, by per-source validation, not by the collapse guard.
 
 A newly introduced source receives a silent first healthy baseline so deployment does not create an alert flood.

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -23,6 +23,16 @@ Operational health warnings are intentionally excluded from the public dashboard
 
 `WATCH_KEYWORDS` in `config.py` controls high-priority matching. Matching is performed against structured titles and descriptions where available. Keyword alerts can produce immediate Webex, webhook, and email notifications in addition to appearing in generated content outputs.
 
+## Webex operational scripts
+
+One-off Webex room maintenance is handled by plaintext scripts under `scripts/webex/`, each run from its own manually-dispatched workflow (checkout + setup-python + run):
+
+- `post_maintenance_notice.py` — post a "resolved, no action needed" notice after a benign failure alert.
+- `delete_failure_alerts.py` — scan the room and delete any messages matching the failure-alert marker.
+- `delete_message_by_id.py` — delete one message by explicit ID (argument or `MESSAGE_ID`).
+
+All three read `CC_WEBEX_BOT_TOKEN` / `CC_WEBEX_ROOM_ID` from the environment. They were previously base64-encoded inside their workflow YAML; keeping them as plaintext scripts makes them reviewable and scannable.
+
 ## Dry run
 
 Set `CC_DRY_RUN=true` to suppress every outbound notification. Generated snapshots, diffs, dashboard files, RSS, and logs remain available for review.


### PR DESCRIPTION
## Docs: sync with collapse guard, Python version, and Webex scripts

Documentation drifted from three of the recently merged changes. No code changes.

### MONITORING.md — collapse guard scope
The "Collection safety" section described last-known-good retention as applying to "the affected domain or NIAP subcollection." Since the per-collection collapse guard landed, that retention also covers any secondary collection (any domain's `pages`/`feeds`/top-level list) that drops below half its prior size from a `COLLAPSE_MIN_BASELINE` baseline — e.g. NIAP `tds`/`pcl_all`/`in_evaluation`, or an EUCC/NIST/CSfC secondary page/feed that would otherwise pass domain-level health while emitting false removals. Also notes the guard covers volume collapse, not small-but-corrupt payloads (which are a per-source validation concern).

### README.md + DEVELOPMENT.md — Python version
Both setup blocks now state the Python 3.10+ requirement (the code uses `X | None` syntax) and call out that the macOS system `python3` is 3.9 and needs a newer interpreter. Setting up on stock macOS previously failed at import with no explanation.

### NOTIFICATIONS.md — Webex scripts
Documents the three `scripts/webex/` tools (`post_maintenance_notice.py`, `delete_failure_alerts.py`, `delete_message_by_id.py`) and their env vars, added when the base64-blob workflows were de-blobbed.
