### PR TITLE
fix: NATO NIAPCL fails gracefully on 403 instead of retrying/bypassing WAF

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -82,12 +82,18 @@ def _do_get_html(url, timeout=30):
             "(bot-detection, IP reputation, or missing browser headers)",
             url,
         )
-        browser_fallback_bases = tuple(
-            str(getattr(config, name, "")).lower()
-            for name in ("CSFC_BASE", "NATO_BASE")
-            if getattr(config, name, "")
-        )
-        if url.lower().startswith(browser_fallback_bases):
+        nato_base = str(getattr(config, "NATO_BASE", "")).lower()
+        if nato_base and url.lower().startswith(nato_base):
+            log.warning(
+                "NATO NIAPCL blocked this request (403) and its own error "
+                "page threatens forensic action against automated access. "
+                "Failing gracefully without retrying or attempting to "
+                "bypass the block; this source will report as stale until "
+                "access is authorized through an official channel."
+            )
+            return None
+        csfc_base = str(getattr(config, "CSFC_BASE", "")).lower()
+        if csfc_base and url.lower().startswith(csfc_base):
             log.info("Retrying WAF-protected page with a Chrome-compatible TLS fingerprint...")
             browser_response = curl_requests.get(
                 url,

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -255,21 +255,16 @@ class TestGetHtml:
         assert fallback.call_args.kwargs["impersonate"] == "chrome"
         browser_response.raise_for_status.assert_called_once()
 
-    def test_nato_403_uses_chrome_impersonation_fallback(self):
+    def test_nato_403_fails_gracefully_without_retry_or_bypass(self):
         blocked = MagicMock()
         blocked.status_code = 403
-        browser_response = MagicMock()
-        browser_response.text = "<html><main>NATO products</main></html>"
 
         with patch.object(collector.SESSION, "get", return_value=blocked):
-            with patch.object(
-                collector.curl_requests, "get", return_value=browser_response
-            ) as fallback:
-                collector._do_get_html(_cfg.NATO_BASE + "/Search/NIAPC")
+            with patch.object(collector, "curl_requests") as fallback:
+                result = collector._do_get_html(_cfg.NATO_BASE + "/Search/NIAPC")
 
-        fallback.assert_called_once()
-        assert fallback.call_args.kwargs["impersonate"] == "chrome"
-        browser_response.raise_for_status.assert_called_once()
+        assert result is None
+        fallback.get.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Why

NATO NIAPCL has been returning HTTP 403 on every scheduled run for roughly the last week and a half (runs #314 onward). The collector was retrying each request 4x with exponential backoff and, on top of that, falling back to a curl_cffi Chrome-TLS-impersonation request specifically to get past the WAF. The site's own error page for blocked requests threatens forensic investigation of automated access, so continuing to retry and spoof a browser fingerprint against it isn't something we should keep doing.

## What changed

- `_do_get_html` now special-cases NATO_BASE: on a 403 it logs a clear warning and returns `None` immediately - no retries, no curl_cffi fallback. This source will simply report as `stale` (last-known-good data retained), consistent with existing monitoring-coverage handling.
- - CSfC's existing WAF-bypass fallback is untouched - this PR only changes NATO NIAPCL behavior.
- - Updated `test_nato_403_uses_chrome_impersonation_fallback` -> `test_nato_403_fails_gracefully_without_retry_or_bypass`, asserting the request returns `None` and `curl_requests` is never invoked.
## Follow-up

Restoring real NIAPCL coverage should go through an authorized channel (e.g. requesting official API/feed access from NCI Agency) rather than further WAF bypass attempts.