### PR TITLE
Remove NIST/CAVP/CMVP monitoring and notifications

### DIFF
--- a/.github/workflows/cc_pulse.yml
+++ b/.github/workflows/cc_pulse.yml
@@ -81,7 +81,6 @@ jobs:
           - cctl_labs
           - csfc
           - cc_crypto
-          - nist
           - nato
           - eucc
           - nd_itc

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ CC Pulse monitors public cybersecurity certification and standards sources, comp
 |---|---|
 | NIAP | Products, Protection Profiles, Technical Decisions, announcements, events, and policy letters |
 | NSA CSfC | Components List, announcements, capability packages, and selection documents |
-| NIST CSRC | News, FIPS publications, CMVP, and post-quantum standards |
 | CC Portal | International news, Protection Profiles, and certified products |
 | NATO NIAPCL | Certified products and Cisco-specific changes |
 | EUCC / ENISA | Scheme requirements and certificates |

--- a/collector.py
+++ b/collector.py
@@ -1,6 +1,6 @@
 """
 collector.py — Pulls all data from NIAP APIs, CC Portal, CCTL labs,
-              CSfC pages, CC Crypto Catalog, and NIST CSRC.
+              CSfC pages, CC Crypto Catalog.
 
 Features:
   - Exponential-backoff retry on every HTTP call
@@ -10,7 +10,6 @@ Features:
   - Sanity-check validation before accepting a snapshot
   - Structured CSfC APL records with component type tagging (fix #18)
   - CCTL scraper health warnings for empty-result detectors (fix #19)
-  - Structured CMVP MIP table parsing with named fields (fix #20)
 """
 
 import hashlib
@@ -142,7 +141,7 @@ def _partial_get_hash(url: str, nbytes: int = 2048) -> str:
     """Fetch the first `nbytes` bytes of a URL and return an MD5 hex-digest.
 
     Used as a fallback when a server does not return useful Last-Modified /
-    ETag headers (common for NSA and NIST PDF servers behind CDNs/WAFs).
+    ETag headers (common for NSA PDF servers behind CDNs/WAFs).
     If the partial GET fails, returns an empty string so the diff logic
     still works without crashing.
     """
@@ -681,22 +680,11 @@ def validate_snapshot(snapshot):
             "CC Portal may be down — snapshot kept but flagged.",
             crypto_pubs_count, config.SANITY_MIN_CC_CRYPTO_PUBS,
         )
-
-    nist_news_count = len(
-        snapshot.get("nist", {}).get("pages", {}).get("news", [])
-    )
-    if nist_news_count < config.SANITY_MIN_NIST_NEWS:
-        log.warning(
-            "NIST CSRC news page returned only %d items (minimum expected: %d). "
-            "NIST CSRC may be down or blocking — snapshot kept but flagged.",
-            nist_news_count, config.SANITY_MIN_NIST_NEWS,
-        )
-
     log.info(
         "[Validation] Sanity checks passed "
-        "(PCL:%d PPs:%d CSfC-APL:%d CSfC-Announcements:%d CryptoPubs:%d NISTNews:%d).",
+        "(PCL:%d PPs:%d CSfC-APL:%d CSfC-Announcements:%d CryptoPubs:%d).",
         pcl_count, pps_count, csfc_apl_count, csfc_announcements_count,
-        crypto_pubs_count, nist_news_count,
+        crypto_pubs_count,
     )
 
 
@@ -1165,7 +1153,6 @@ def collect_all(validate: bool = True):
         "cctl_labs": collect_cctl_labs,
         "csfc":      collect_csfc,
         "cc_crypto": collect_cc_crypto,
-        "nist":      collect_nist,
         "nato":      collect_nato,
         "eucc":      collect_eucc,
         "nd_itc":    collect_nd_itc,
@@ -1203,7 +1190,6 @@ def collect_all(validate: bool = True):
         "cctl_labs":      results.get("cctl_labs", {}),
         "csfc":           results.get("csfc",      {}),
         "cc_crypto":      results.get("cc_crypto", {}),
-        "nist":           results.get("nist",      {}),
         "nato":           results.get("nato",      {}),
         "eucc":           results.get("eucc",      {}),
         "nd_itc":         results.get("nd_itc",    {}),
@@ -1523,111 +1509,8 @@ def collect_cc_crypto() -> dict:
     return data
 
 
-# ── NIST CSRC Monitoring ──────────────────────────────────────────────────────
-def _scrape_nist_page(path: str) -> list:
-    """Scrape a NIST CSRC page and return a list of text/link items."""
-    url  = config.NIST_CSRC_BASE + path
-    soup = get_html(url)
-    if not soup:
-        return []
-    items = []
 
-    # The news page uses result cards below #body-section. A generic
-    # ``.container`` appears much earlier in the government-site header, so
-    # selecting that container first silently produced an empty news snapshot.
-    if path.rstrip("/").lower() == "/news":
-        for title in soup.select(".news-list-title"):
-            link = title.find("a", href=True)
-            text = (
-                link.get_text(" ", strip=True)
-                if link else title.get_text(" ", strip=True)
-            )
-            if not text:
-                continue
-            href = urljoin(url, link.get("href", "")) if link else ""
-            items.append({"text": text[:400], "href": href})
-        if items:
-            return items
-
-    content = (
-        soup.find("div", {"id": "body-section"})
-        or soup.find("div", {"id": "main-content"})
-        or soup.find("main")
-        or soup.find("div", {"class": "container"})
-        or soup
-    )
-    # CMVP MIP page uses a table — extract rows as structured records (fix #20)
-    # Columns (as of 2024): Vendor | Module Name | FIPS Cert # | Validation Auth Date | Status
-    table = content.find("table") if content else None
-    if table:
-        headers_raw = [th.get_text(strip=True) for th in table.find_all("th")]
-        for tr in table.find_all("tr")[1:]:
-            cells = [td.get_text(strip=True) for td in tr.find_all("td")]
-            if not cells:
-                continue
-            link_tag = tr.find("a")
-            href = link_tag["href"] if link_tag and link_tag.get("href") else ""
-            # Build a named-field record when headers are available
-            if headers_raw and len(headers_raw) >= len(cells):
-                record = dict(zip(headers_raw, cells))
-                record["href"] = href
-                # Also include a text summary for backwards compat with existing diff logic
-                record["text"] = " | ".join(cells[:4])[:400]
-            else:
-                record = {"text": " | ".join(cells[:4])[:400], "href": href}
-            items.append(record)
-    else:
-        for tag in content.find_all(["h2", "h3", "h4", "p", "li", "td"]):
-            text = tag.get_text(separator=" ", strip=True)
-            link = tag.find("a")
-            href = link["href"] if link and link.get("href") else ""
-            if len(text) > 20:
-                items.append({"text": text[:400], "href": href})
-    seen:   set = set()
-    unique: list = []
-    for item in items:
-        key = item["text"][:120]
-        if key not in seen:
-            seen.add(key)
-            unique.append(item)
-    return unique
-
-def collect_nist() -> dict:
-    """Collect NIST CSRC monitoring data:
-      - CSRC page snapshots (news, FIPS, CMVP MIP, PQC project, crypto standards)
-      - HTTP header polling of key NIST crypto PDFs (with partial-GET fallback)
-      - NIST cybersecurity RSS feeds
-    """
-    log.info("[NIST] Collecting...")
-    data: dict = {
-        "pages": {},
-        "feeds": {},
-    }
-
-    for page_key, path in config.NIST_CSRC_PAGES.items():
-        log.debug("  [NIST] Scraping page: %s (%s)...", page_key, path)
-        data["pages"][page_key] = _scrape_nist_page(path)
-        log.debug("    -> %d items", len(data["pages"][page_key]))
-
-    for feed in config.NIST_FEEDS:
-        name = feed["name"]
-        log.debug("  [NIST] Feed: %s...", name)
-        if feed.get("rss"):
-            items = get_rss(feed["rss"])
-        elif feed.get("scrape") and feed.get("url"):
-            items = scrapelab_items(feed["url"])
-        else:
-            items = []
-        data["feeds"][name] = items
-        log.debug("    -> %d items", len(items))
-
-    news_count = len(data["pages"].get("news", []))
-    mip_count  = len(data["pages"].get("cmvp_mip", []))
-    log.info("[NIST] news-items:%d cmvp-mip-modules:%d", news_count, mip_count)
-    return data
-
-
-# ── Per-domain CLI entry point (issue #20 — parallel matrix support) ─────────────────
+# ── Per-domain CLI entry point (issue #20 — parallel matrix support) ─────────────────────────────────────────
 
 #: Maps domain name → collector function.
 #: Used by `collect_domain()` and the `--domain` CLI flag so that each
@@ -1639,7 +1522,6 @@ DOMAIN_COLLECTORS: dict = {
     "cctl_labs": collect_cctl_labs,
     "csfc":      collect_csfc,
     "cc_crypto": collect_cc_crypto,
-    "nist":      collect_nist,
     "nato":      collect_nato,
     "eucc":      collect_eucc,
     "nd_itc":    collect_nd_itc,
@@ -1653,7 +1535,7 @@ def collect_domain(name: str, out_dir: str = "snapshots/partial") -> dict:
     matrix job.  The partial file is later merged by `main.py --merge`.
 
     Args:
-        name:    One of the keys in DOMAIN_COLLECTORS (e.g. "niap", "nist").
+        name:    One of the keys in DOMAIN_COLLECTORS (e.g. "niap", "csfc").
         out_dir: Directory in which to write `<name>.json`.  Created if absent.
 
     Returns:
@@ -1704,7 +1586,7 @@ if __name__ == "__main__":
         "--domain",
         required=True,
         choices=sorted(DOMAIN_COLLECTORS),
-        help="Domain to collect (e.g. niap, nist, nato).",
+        help="Domain to collect (e.g. niap, csfc, nato).",
     )
     parser.add_argument(
         "--out-dir",

--- a/config.py
+++ b/config.py
@@ -61,7 +61,6 @@ SANITY_MIN_PPS = 10
 SANITY_MIN_CSFC_APL = 5
 SANITY_MIN_CSFC_ANNOUNCEMENTS = 1
 SANITY_MIN_CC_CRYPTO_PUBS = 5
-SANITY_MIN_NIST_NEWS = 10
 
 # -- Per-collection collapse guard ------------------------------------------
 # A domain can pass its representative sanity check (e.g. NIAP PCL is fine)
@@ -130,12 +129,7 @@ NEWS_CATEGORY_KEYWORDS = {
         "key establishment", "digital signature", "hash function",
         "random bit generator", "rbg", "algorithm transition",
     ],
-    "NIST": [
-        "nist", "fips 140", "fips 186", "fips 197", "fips 203", "fips 204", "fips 205",
-        "sp 800", "cmvp", "cavp", "post-quantum", "pqc",
-        "ml-kem", "ml-dsa", "slh-dsa", "csrc",
-    ],
-    "NEWS": [],
+        "NEWS": [],
 }
 
 # -- Watch Keywords (high-priority alert terms) -----------------------------
@@ -172,24 +166,6 @@ WATCH_KEYWORDS = [
     "FCS_CKM",
     "FCS_COP",
     "FCS_RBG",
-    "CAVP",
-    "CMVP",
-    # -- NIST / CSRC ---------------------------------------------------
-    "FIPS 140-3",
-    "FIPS 203",
-    "FIPS 204",
-    "FIPS 205",
-    "SP 800-131A",
-    "SP 800-57",
-    "NIST IR 8547",
-    "post-quantum cryptography",
-    "PQC migration",
-    "ML-KEM",
-    "ML-DSA",
-    "SLH-DSA",
-    "algorithm transition",
-    "CMVP validated",
-    "modules in process",
 ]
 
 # NOTE: BODY_WATCH_KEYWORDS was removed (2026-07-10). It was never referenced
@@ -345,33 +321,3 @@ CC_CRYPTO_NEWS_KEYWORDS = [
     "digital signature", "hash function", "random bit generator", "rbg",
 ]
 
-# =============================================================
-# NIST CSRC Monitoring
-# =============================================================
-NIST_CSRC_BASE = "https://csrc.nist.gov"
-NIST_BASE = "https://www.nist.gov"
-
-NIST_CSRC_PAGES = {
-    "news": "/news",
-    "fips": "/publications/fips",
-    "cmvp_mip": "/projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list",
-    "pqc": "/projects/post-quantum-cryptography",
-    "crypto_standards":"/projects/cryptographic-standards-and-guidelines",
-    "cmvp_validated": "/projects/cryptographic-module-validation-program/validated-modules",
-}
-
-# NIST_CRYPTO_DOCS removed (fix #27): doc header polling was unreliable.
-# NIST changes are tracked via NIST_CSRC_PAGES scrapes and NIST_FEEDS RSS.
-
-NIST_FEEDS = [
-    {"name": "NIST Cybersecurity News", "rss": "https://www.nist.gov/news-events/cybersecurity/rss.xml", "scrape": False},
-    {"name": "NIST Information Technology News", "rss": "https://www.nist.gov/news-events/information%20technology/rss.xml", "scrape": False},
-    {"name": "NIST Cybersecurity Insights Blog", "rss": "https://www.nist.gov/blogs/cybersecurity-insights/rss.xml", "scrape": False},
-]
-
-NIST_NEWS_KEYWORDS = [
-    "nist", "fips 140", "fips 186", "fips 197", "fips 203", "fips 204", "fips 205",
-    "sp 800", "cmvp", "cavp", "post-quantum", "pqc",
-    "ml-kem", "ml-dsa", "slh-dsa", "algorithm transition",
-    "key management", "cryptographic module", "csrc",
-]

--- a/dashboard.py
+++ b/dashboard.py
@@ -3,7 +3,7 @@ dashboard.py -- Renders the daily HTML dashboard and RSS feed.
 
 Features:
   - Keyword alert banner (red, top of page)
-  - Trend summary stats panel with anchor links (NIAP + CSfC + CC Crypto + NIST)
+  - Trend summary stats panel with anchor links (NIAP + CSfC + CC Crypto)
   - Collapsible cards (empty sections auto-collapsed)
   - Color-coded section headers (green=new, amber=updated, red=removed/alert)
   - Clickable source links on all items
@@ -51,7 +51,7 @@ def _build_history(n: int = 90) -> list:
       date      - YYYY-MM-DD string
       category  - one of: cisco_cert, cisco_archived, pp_new, pp_removed,
                           td_new, nato_cisco, eucc_cisco, in_eval_new,
-                          in_eval_removed, csfc_change, nist_doc, pcl_cert
+                          in_eval_removed, csfc_change, pcl_cert
       kind      - 'new' | 'removed' | 'updated'
       title     - human-readable one-liner
       detail    - optional sub-text (lab, PPs, etc.)
@@ -199,17 +199,6 @@ def _build_history(n: int = 90) -> list:
                 "url": url,
             })
 
-        # NIST page changes
-        for page_key, page_diff in d.get("nist", {}).get("pages", {}).items():
-            if isinstance(page_diff, dict):
-                for item in page_diff.get("added", []):
-                    entries.append({
-                        "date": date, "category": "nist_doc", "kind": "updated",
-                        "title": f"NIST {page_key}: {(item.get('text') or '')[:60]}",
-                        "detail": "",
-                        "url": item.get("href") or "https://csrc.nist.gov/",
-                    })
-
         # CSfC component selection changes
         for sel_name, sel_data in d.get("csfc", {}).get("selection_links", {}).items():
             if sel_data.get("changed"):
@@ -278,8 +267,6 @@ def _section_daily_counts(diffs: list, section_key: str) -> list:
             )
         elif section_key == "cc_crypto":
             n = sum(len(p.get("added", [])) for p in d.get("cc_crypto", {}).get("pages", {}).values() if isinstance(p, dict))
-        elif section_key == "nist":
-            n = sum(len(p.get("added", [])) for p in d.get("nist", {}).get("pages", {}).values() if isinstance(p, dict))
         elif section_key == "pcl_all":
             pa = d.get("niap", {}).get("pcl_all", {})
             n = (len(pa.get("added", [])) + len(pa.get("removed", [])) +
@@ -508,14 +495,6 @@ DASHBOARD_TEMPLATE = """
         <div class="sources-item"><span class="src-label">CISA Alerts (RSS):</span><a href="https://www.cisa.gov/cybersecurity-advisories/all.xml" target="_blank" rel="noopener">cisa.gov &mdash; All Advisories</a></div>
       </div>
       <div class="sources-group">
-        <div class="sources-group-title">🇳🇮 NIST CSRC</div>
-        <div class="sources-item"><span class="src-label">News:</span><a href="https://csrc.nist.gov/news" target="_blank" rel="noopener">csrc.nist.gov &mdash; CSRC News</a></div>
-        <div class="sources-item"><span class="src-label">FIPS Publications:</span><a href="https://csrc.nist.gov/publications/fips" target="_blank" rel="noopener">csrc.nist.gov &mdash; FIPS Pubs</a></div>
-        <div class="sources-item"><span class="src-label">CMVP (Modules In Process):</span><a href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list" target="_blank" rel="noopener">csrc.nist.gov &mdash; CMVP MIP</a></div>
-        <div class="sources-item"><span class="src-label">Post-Quantum Crypto:</span><a href="https://csrc.nist.gov/projects/post-quantum-cryptography" target="_blank" rel="noopener">csrc.nist.gov &mdash; PQC Project</a></div>
-        <div class="sources-item"><span class="src-label">NIST News (RSS):</span><a href="https://www.nist.gov/news-events/cybersecurity/rss.xml" target="_blank" rel="noopener">nist.gov &mdash; Cybersecurity RSS (⚠️ empty feed)</a></div>
-      </div>
-      <div class="sources-group">
         <div class="sources-group-title">🌐 CC Portal (International)</div>
         <div class="sources-item"><span class="src-label">News:</span><a href="https://www.commoncriteriaportal.org/news/index.cfm" target="_blank" rel="noopener">commoncriteriaportal.org &mdash; News</a></div>
         <div class="sources-item"><span class="src-label">Products:</span><a href="https://www.commoncriteriaportal.org/products/index.cfm" target="_blank" rel="noopener">commoncriteriaportal.org &mdash; Products</a></div>
@@ -562,10 +541,6 @@ DASHBOARD_TEMPLATE = """
     <div class="stat"><a href="#sec-csfc" onclick="navigateTo('sec-csfc');return false;">
       <div class="stat-num {% if csfc_total_stat > 0 %}active-num{% endif %}">{{ csfc_total_stat }}</div>
       <div class="stat-lbl">CSfC Selection Updates</div>
-    </a></div>
-    <div class="stat"><a href="#sec-nist" onclick="navigateTo('sec-nist');return false;">
-      <div class="stat-num {% if nist_total_stat > 0 %}active-num{% endif %}">{{ nist_total_stat }}</div>
-      <div class="stat-lbl">NIST Doc Updates</div>
     </a></div>
     <div class="stat"><a href="#sec-cc-portal" onclick="navigateTo('sec-cc-portal');return false;">
       <div class="stat-num {% if cc_portal_total_stat > 0 %}active-num{% endif %}">{{ cc_portal_total_stat }}</div>
@@ -635,7 +610,7 @@ DASHBOARD_TEMPLATE = """
 </div>
 {% endif %}
 <div class="tab-nav" id="region-tabs">
-        <button class="tab-btn active" data-tab="us" onclick="switchTab(this)">&#127482;&#127480; US (NIAP / CSfC / NIST)</button>
+        <button class="tab-btn active" data-tab="us" onclick="switchTab(this)">&#127482;&#127480; US (NIAP / CSfC)</button>
         <button class="tab-btn" data-tab="intl" onclick="switchTab(this)">&#127760; International</button>
         <button class="tab-btn" data-tab="eu" onclick="switchTab(this)">&#127466;&#127482; EU (EUCC / ENISA)</button>
       
@@ -972,26 +947,6 @@ DASHBOARD_TEMPLATE = """
   </div>
 </div>
 
-  <!-- NIST Docs -->
-<div class="card {% if nist_total > 0 %}card-updated{% endif %}" id="sec-nist" data-has-changes="{{ nist_total }}">
-  <div class="card-hdr" onclick="toggleCard(this)">
-    <span>NIST Documentation</span>
-    <span class="card-count">{{ nist_total }} update{% if nist_total != 1 %}s{% endif %}</span>
-    </span>
-    <span class="toggle-icon">{% if nist_total == 0 %}&#9658;{% else %}&#9660;{% endif %}</span>
-  </div>
-  <div class="card-body {% if nist_total == 0 %}collapsed{% endif %}">
-    {% for page_key, page_diff in diff.nist.pages.items() %}
-      {% for item in page_diff.added %}
-      <div class="item-row" data-source="nist" data-kind="updated">
-        <a class="item-link" href="{{ (item.href or 'https://csrc.nist.gov/') | safe_url }}" target="_blank">{{ item.text or page_key }}</a>
-        <span class="item-meta">{{ page_key }}</span>
-      </div>
-      {% endfor %}
-    {% endfor %}
-    {% if nist_total == 0 %}<p class="no-change">No changes detected.{% if last_active.nist %} <span class="last-active">(last: {{ last_active.nist }})</span>{% endif %}</p>{% endif %}
-  </div>
-</div>
 </div>
 <div class="section-group" id="tab-pane-intl" data-tab="intl">
         <div class="section-label">International</div>
@@ -1180,8 +1135,7 @@ DASHBOARD_TEMPLATE = """
       <button class="tl-filter-btn" data-cat="nato_cisco" onclick="filterHistory(this)">🛡 NATO</button>
       <button class="tl-filter-btn" data-cat="eucc_cisco" onclick="filterHistory(this)">🇪🇺 EUCC</button>
       <button class="tl-filter-btn" data-cat="csfc_change" onclick="filterHistory(this)">🔒 CSfC</button>
-      <button class="tl-filter-btn" data-cat="nist_doc" onclick="filterHistory(this)">📐 NIST</button>
-    </div>
+      div>
     <div class="timeline" id="history-timeline">
     {% if history_entries %}
       {% for entry in history_entries %}
@@ -1207,7 +1161,7 @@ DASHBOARD_TEMPLATE = """
 
 </div><!-- /main-content -->
 <footer>
-  <span>CC Pulse &middot; Auto-refreshes daily (01:00 EST) &middot; NIAP, CSfC, NIST, CC Portal, NATO NIAPCL, EUCC / ENISA</span>
+  <span>CC Pulse &middot; Auto-refreshes daily (01:00 EST) &middot; NIAP, CSfC, CC Portal, NATO NIAPCL, EUCC / ENISA</span>
   <span>Last run: {{ generated_at }}</span>
 </footer>
 
@@ -1578,15 +1532,6 @@ def _build_rss(diff: dict, generated_at: str) -> str:
                     f"<description>CSfC {xml_escape(page_key)} item {change_label.lower()}.</description></item>"
                 )
 
-    for page_key, page_diff in diff.get("nist", {}).get("pages", {}).items():
-        for item in page_diff.get("added", []):
-            link = item.get("href", "https://csrc.nist.gov/")
-            items_xml.append(
-                f"<item><title>{xml_escape('NIST ' + page_key + ': ' + (item.get('text') or '')[:60])}</title>"
-                f"<link>{xml_escape(link)}</link>"
-                f"<description>New item on NIST CSRC {xml_escape(page_key)} page.</description></item>"
-            )
-
     for page_key, page_diff in diff.get("cc_crypto", {}).get("pages", {}).items():
         for item in page_diff.get("added", []):
             link = item.get("href", "https://www.commoncriteriaportal.org/")
@@ -1674,7 +1619,6 @@ def render_dashboard(diff: dict, output_dir: str = "docs") -> None:
         if page_key in ("apl", "announcements") and isinstance(page_diff, dict)
     )
     cc_crypto_total = sum(len(p.get("added", [])) for p in diff.get("cc_crypto", {}).get("pages", {}).values() if isinstance(p, dict))
-    nist_total      = sum(len(p.get("added", [])) for p in diff.get("nist", {}).get("pages", {}).values() if isinstance(p, dict))
     alert_total     = len(diff.get("alerts", []))
 
     niap_total_stat = (
@@ -1683,7 +1627,6 @@ def render_dashboard(diff: dict, output_dir: str = "docs") -> None:
     )
     cctl_total_stat = cctl_total
     csfc_total_stat = csfc_total
-    nist_total_stat = nist_total + cc_crypto_total
 
 
     # CC Portal totals
@@ -1725,7 +1668,7 @@ def render_dashboard(diff: dict, output_dir: str = "docs") -> None:
         return None
     last_active = {k: _last_active(k) for k in [
         "niap_pp","niap_td","niap_news","cctl","csfc",
-        "cc_crypto","nist","cc_portal","pcl_all","in_eval"
+        "cc_crypto","cc_portal","pcl_all","in_eval"
     ]}
 
     # Render template. autoescape=True so scraped/vendor-controlled strings
@@ -1757,12 +1700,10 @@ def render_dashboard(diff: dict, output_dir: str = "docs") -> None:
         cctl_total      = cctl_total,
         csfc_total      = csfc_total,
         cc_crypto_total = cc_crypto_total,
-        nist_total      = nist_total,
         alert_total     = alert_total,
         niap_total_stat = niap_total_stat,
         cctl_total_stat = cctl_total_stat,
         csfc_total_stat = csfc_total_stat,
-        nist_total_stat = nist_total_stat,
         cc_portal_total      = cc_portal_total,
         cc_portal_total_stat = cc_portal_total_stat,
         period_start         = diff.get("period_start", ""),

--- a/differ.py
+++ b/differ.py
@@ -314,88 +314,6 @@ def flag_alerts(diff: Snapshot) -> list[dict]:
                 _add_text(f"CC Crypto: {page_key}", "publication",
                           item.get("text", ""),
                           url=page_url, detail=detail, tab="us")
-
-    # NIST page changes — fire unconditionally for high-value pages (fix #27)
-    # FIPS publications and CSRC news are always worth notifying on.
-    # Other pages (PQC, crypto standards, CMVP validated) still keyword-filter.
-    _nist_page_urls = {
-        "news": "https://csrc.nist.gov/news",
-        "fips": "https://csrc.nist.gov/publications/fips",
-        "cmvp_mip": "https://csrc.nist.gov/projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list",
-        "pqc": "https://csrc.nist.gov/projects/post-quantum-cryptography",
-        "crypto_standards":"https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines",
-        "cmvp_validated": "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules",
-    }
-    _nist_unconditional_pages = {"news", "fips"}  # always notify, no keyword filter needed
-    for page_key, page_diff in diff.get("nist", {}).get("pages", {}).items():
-        # cmvp_mip is diffed structurally below (added/status_changes with
-        # meaningful old→new detail). Scanning its raw page text here double-
-        # reported every status change: the changed row text looked like a
-        # "new item" and matched "FIPS 140-3" (present in every MIP row),
-        # producing a second, uninformative alert per module (2026-07-09).
-        if page_key == "cmvp_mip":
-            continue
-        if isinstance(page_diff, dict):
-            items_to_check = page_diff.get("added", [])
-        else:
-            items_to_check = []
-        for item in items_to_check:
-            page_url = item.get("href") or _nist_page_urls.get(page_key, "https://csrc.nist.gov/")
-            detail = f"New item on NIST CSRC {page_key.replace('_', ' ')} page"
-            if page_key in _nist_unconditional_pages:
-                # Always alert — no keyword filter
-                title = item.get("text", "")[:120]
-                _add(alerts, f"NIST: {page_key}", "publication", title,
-                     url=page_url, detail=detail, tab="us")
-            else:
-                _add_text(f"NIST: {page_key}", "publication",
-                          item.get("text", ""),
-                          url=page_url, detail=detail, tab="us")
-
-    # CMVP MIP changes — alert on Cisco modules only (fix #27, narrowed).
-    # The full MIP list churns constantly across all vendors; those moves are
-    # visible on the dashboard but only Cisco's own modules warrant an
-    # immediate email/Webex alert.
-    def _is_cisco_module(rec: dict) -> bool:
-        blob = " ".join(
-            str(rec.get(k) or "")
-            for k in ("Module Name", "name", "Vendor", "vendor", "text")
-        ).lower()
-        return any(kw in blob for kw in config.CISCO_VENDOR_KEYWORDS)
-
-    cmvp_mip = diff.get("nist", {}).get("cmvp_mip", {})
-    for item in cmvp_mip.get("added", []):
-        if not _is_cisco_module(item):
-            continue
-        name = item.get("Module Name") or item.get("name") or item.get("text", "")[:80]
-        vendor = item.get("Vendor") or item.get("vendor") or ""
-        status = item.get("Status") or item.get("status") or ""
-        title = f"{name}" + (f" ({vendor})" if vendor else "")
-        detail = f"New module in CMVP modules-in-process" + (f" — Status: {status}" if status else "")
-        _add(alerts, "NIST CMVP MIP", "new", title,
-             url=_nist_page_urls["cmvp_mip"], detail=detail,
-             keywords=["cisco", "CMVP"], tab="us")
-    for item in cmvp_mip.get("status_changes", []):
-        if not _is_cisco_module(item):
-            continue
-        name = item.get("Module Name") or item.get("name") or item.get("text", "")[:80]
-        vendor = item.get("Vendor") or item.get("vendor") or ""
-        title = f"{name}" + (f" ({vendor})" if vendor else "")
-        detail = f"CMVP status: {item.get('old_status', '?')} → {item.get('new_status', '?')}"
-        _add(alerts, "NIST CMVP MIP", "updated", title,
-             url=_nist_page_urls["cmvp_mip"], detail=detail,
-             keywords=["cisco", "CMVP"], tab="us")
-
-    # NIST RSS feed new items — always alert (all items are crypto/security relevant)
-    for feed_name, items in diff.get("nist", {}).get("feeds", {}).items():
-        for item in items:
-            title = item.get("title", "")
-            _add(alerts, f"NIST Feed: {feed_name}", "news",
-                 title,
-                 url=item.get("link") or "https://csrc.nist.gov/",
-                 detail=f"Feed: {feed_name} · Published: {(item.get('published') or '')[:16] or 'N/A'}",
-                 tab="us")
-
     # NATO NIAPCL — Cisco additions are alert-worthy by construction (the
     # list is already Cisco-filtered), so they use unconditional _add with an
     # explicit "cisco" keyword rather than the keyword-gated _add_text. The
@@ -806,43 +724,6 @@ def _diff_doc_headers(old_docs: dict, new_docs: dict) -> dict:
             }
     return result
 
-def _diff_cmvp_mip(old_mip: list, new_mip: list) -> dict:
-    """Diff CMVP modules-in-process by module name.
-
-    Tracks:
-    - added: new modules appearing in MIP list
-    - removed: modules that left the MIP list (validated or withdrawn)
-    - status_changes: modules whose validation status changed
-
-    Each record is expected to have 'Module Name' and 'Status' fields
-    (from the structured CMVP MIP table parser in collector.py).
-    Returns a dict with 'added', 'removed', 'status_changes' lists.
-    """
-    def _key(r: dict) -> str:
-        return (r.get("Module Name") or r.get("name") or r.get("text") or "").strip().lower()
-
-    old_map = {_key(r): r for r in old_mip if _key(r)}
-    new_map = {_key(r): r for r in new_mip if _key(r)}
-
-    added = [new_map[k] for k in set(new_map) - set(old_map)]
-    removed = [old_map[k] for k in set(old_map) - set(new_map)]
-
-    status_changes = []
-    for k in set(old_map) & set(new_map):
-        old_status = (old_map[k].get("Status") or old_map[k].get("status") or "").strip()
-        new_status = (new_map[k].get("Status") or new_map[k].get("status") or "").strip()
-        if old_status and new_status and old_status != new_status:
-            status_changes.append({
-                **new_map[k],
-                "old_status": old_status,
-                "new_status": new_status,
-            })
-
-    log.debug("[CMVP MIP Diff] added:%d removed:%d status_changes:%d",
-              len(added), len(removed), len(status_changes))
-    return {"added": added, "removed": removed, "status_changes": status_changes}
-
-
 def _diff_selection_links(old_links: dict, new_links: dict) -> dict:
     """Diff two {category_heading: full_href} dicts.
 
@@ -1143,8 +1024,6 @@ def compute_diff(old_snapshot: Snapshot, new_snapshot: Snapshot) -> Snapshot:
     new_cs = new_snapshot.get("csfc", {})
     old_cc = old_snapshot.get("cc_crypto", {})
     new_cc = new_snapshot.get("cc_crypto", {})
-    old_ni = old_snapshot.get("nist", {})
-    new_ni = new_snapshot.get("nist", {})
     old_na = old_snapshot.get("nato", {})
     new_na = new_snapshot.get("nato", {})
     old_eu = old_snapshot.get("eucc", {})
@@ -1171,7 +1050,6 @@ def compute_diff(old_snapshot: Snapshot, new_snapshot: Snapshot) -> Snapshot:
         "cctl_labs": diff_cctl_labs(old_l, new_l),
         "csfc": diff_csfc(old_cs, new_cs),
         "cc_crypto": diff_cc_crypto(old_cc, new_cc),
-        "nist": diff_nist(old_ni, new_ni),
         "nato": diff_nato(old_na, new_na),
         "eucc": diff_eucc(old_eu, new_eu),
         "nd_itc": diff_nd_itc(old_snapshot.get("nd_itc", {}),
@@ -1227,7 +1105,6 @@ def merge_weekly_diffs(diffs: list[Snapshot]) -> Snapshot:
         ("cctl_labs", {}),
         ("csfc", {"feeds": {}, "pages": {}, "selection_links": {}}),
         ("cc_crypto", {"pages": {}}),
-        ("nist", {"pages": {}, "cmvp_mip": {"added": [], "removed": [], "status_changes": []}, "feeds": {}}),
         ("nato", {"pages": {}, "cisco_added": [], "cisco_removed": []}),  # fix #23
         ("eucc", {"pages": {}, "cisco_added": [], "cisco_removed": []}),  # fix #23
         ("nd_itc", copy.deepcopy(_EMPTY_ND_ITC_DIFF)),
@@ -1245,12 +1122,6 @@ def merge_weekly_diffs(diffs: list[Snapshot]) -> Snapshot:
         "policies": {"added": [], "revised": [], "archived": [], "reactivated": [], "removed": []},
     }.items():
         weekly["niap"].setdefault(key, copy.deepcopy(default))
-    weekly.setdefault("nist", {})
-    weekly["nist"].setdefault("pages", {})
-    weekly["nist"].setdefault(
-        "cmvp_mip", {"added": [], "removed": [], "status_changes": []}
-    )
-    weekly["nist"].setdefault("feeds", {})
     for d in diffs[1:]:
         # Health is point-in-time metadata; the latest day wins.
         if "source_health" in d:
@@ -1317,21 +1188,6 @@ def merge_weekly_diffs(diffs: list[Snapshot]) -> Snapshot:
                 weekly["cc_crypto"]["pages"][page_key]["added"] = merge_lists(
                     weekly["cc_crypto"]["pages"][page_key]["added"], page_diff["added"])
 
-        # NIST
-        for page_key, page_diff in d.get("nist", {}).get("pages", {}).items():
-            if isinstance(page_diff, dict) and "added" in page_diff:
-                if page_key not in weekly["nist"]["pages"]:
-                    weekly["nist"]["pages"][page_key] = {"added": []}
-                weekly["nist"]["pages"][page_key]["added"] = merge_lists(
-                    weekly["nist"]["pages"][page_key]["added"], page_diff["added"])
-        # cmvp_mip: take latest status_changes / added (last day wins — avoid duplicates)
-        for key in ("added", "removed", "status_changes"):
-            weekly["nist"]["cmvp_mip"][key] = merge_lists(
-                weekly["nist"].get("cmvp_mip", {}).get(key, []),
-                d.get("nist", {}).get("cmvp_mip", {}).get(key, []))
-        for feed_name, items in d.get("nist", {}).get("feeds", {}).items():
-            weekly["nist"]["feeds"][feed_name] = merge_lists(
-                weekly["nist"]["feeds"].get(feed_name, []), items)
         # NATO -- fix #23: merge nato pages and cisco_added/removed
         for page_key, page_diff in d.get("nato", {}).get("pages", {}).items():
             if isinstance(page_diff, dict) and "added" in page_diff:
@@ -1407,36 +1263,3 @@ def diff_cc_crypto(old_cc: Snapshot, new_cc: Snapshot) -> Snapshot:
     page_changes = sum(len(v.get("added", [])) for v in pages.values())
     log.info("[CC Crypto Diff] page-items-added:%d", page_changes)
     return {"pages": pages}
-
-# -- NIST CSRC diff ------------------------------------------------------------
-def diff_nist(old_nist: Snapshot, new_nist: Snapshot) -> Snapshot:
-    """Diff two NIST CSRC snapshots.
-
-    Doc header polling removed (fix #27): CDN header rotation produced
-    false positives with no actionable signal. NIST changes are now
-    tracked via page scrapes (news, FIPS, CMVP MIP) and RSS feeds.
-    CMVP MIP is diffed as a structured list to track module status changes.
-    """
-    pages = _diff_pages(old_nist.get("pages", {}), new_nist.get("pages", {}))
-    feeds = _diff_feeds(
-        old_nist.get("feeds", {}),
-        new_nist.get("feeds", {}),
-        categorize=True,
-    )
-    # Structured CMVP MIP diff (fix #27)
-    old_mip = old_nist.get("pages", {}).get("cmvp_mip", [])
-    new_mip = new_nist.get("pages", {}).get("cmvp_mip", [])
-    # cmvp_mip pages entry is a list of structured records from the table parser
-    if isinstance(old_mip, dict):
-        old_mip = old_mip.get("added", [])
-    if isinstance(new_mip, dict):
-        new_mip = new_mip.get("added", [])
-    cmvp_mip = _diff_cmvp_mip(old_mip, new_mip)
-
-    page_changes = sum(len(v.get("added", [])) for v in pages.values() if isinstance(v, dict))
-    feed_new = sum(len(v) for v in feeds.values())
-    log.info(
-        "[NIST Diff] page-items-added:%d cmvp-added:%d cmvp-status-changes:%d feed-new:%d",
-        page_changes, len(cmvp_mip["added"]), len(cmvp_mip["status_changes"]), feed_new,
-    )
-    return {"pages": pages, "cmvp_mip": cmvp_mip, "feeds": feeds}

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -12,7 +12,7 @@ CC Pulse collects public records into dated JSON snapshots and compares each acc
 | NIAP announcements and events | Additions, revisions, deactivations, reactivations, and removals |
 | NIAP policies | Active/archived transitions, metadata revisions, addendum changes, removals, and PDF SHA-256 changes |
 | NSA CSfC | Components List additions/removals, announcements, and selection-link version changes |
-| NIST CSRC and CC Crypto | New page items, feed items, documents, and CMVP changes |
+| CC Crypto | New page items, feed items, and documents |
 | CC Portal and CCTL labs | New international portal records and laboratory posts |
 | NATO NIAPCL and EUCC | Product/certificate additions, removals, and Cisco-specific changes |
 | ND-iTC | NIT RFI additions, status changes, revisions, and archival; Allowed-With list entry additions/removals, version changes, and list-document updates |
@@ -31,7 +31,7 @@ Each source domain is validated before diffing. NIAP announcements, events, and 
 
 When a collection fails, is incomplete, or drops suspiciously:
 
-1. The affected collection keeps its last-known-good records. This applies at three levels: a whole domain that fails its representative check, a NIAP subcollection (announcements, events, policies) validated independently, and any secondary collection — any domain's `pages`/`feeds`/top-level list — that collapses to below half its prior size from a baseline of at least `COLLAPSE_MIN_BASELINE` items. The last catches partial-fetch collapses in collections that aren't the domain's representative check (for example a NIAP `tds`/`pcl_all`/`in_evaluation` list, or an EUCC/NIST/CSfC secondary page/feed) which would otherwise pass domain-level health while emitting false removals.
+1. The affected collection keeps its last-known-good records. This applies at three levels: a whole domain that fails its representative check, a NIAP subcollection (announcements, events, policies) validated independently, and any secondary collection — any domain's `pages`/`feeds`/top-level list — that collapses to below half its prior size from a baseline of at least `COLLAPSE_MIN_BASELINE` items. The last catches partial-fetch collapses in collections that aren't the domain's representative check (for example a NIAP `tds`/`pcl_all`/`in_evaluation` list, or an EUCC/CSfC secondary page/feed) which would otherwise pass domain-level health while emitting false removals.
 2. Healthy domains continue normally; a collection collapse downgrades only the affected domain to `stale`, carrying its failure counter forward.
 3. The degraded state is recorded in `source_health` metadata and workflow logs.
 4. No false mass-removal diff is generated.

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -22,12 +22,8 @@ Notices are suppressed when the source diff is flagged as a baseline reset (see 
 Alert emails and Webex messages sort matches into three tiers:
 
 1. **Cisco-relevant** — a matched keyword names Cisco itself, NDcPP/PP-Modules, CSfC programmes, or FCS_* crypto SFRs. Broad standards identifiers (FIPS 140-3, FIPS 186-x, SP 800-131A) deliberately do *not* confer this tier: they appear in boilerplate (every CMVP MIP row contains "FIPS 140-3") and previously mislabeled other vendors' modules as Cisco-relevant.
-2. **Standards/NIST** — standards identifiers and transition keywords (FIPS 140-3/203/204/205, CMVP, CAVP, PQC terms).
+2. **Standards** — standards identifiers and transition keywords (FIPS 140-3/203/204/205, PQC terms).
 3. **General** — everything else that matched a watch keyword.
-
-## CMVP Modules-in-Process
-
-Only **Cisco modules** on the CMVP MIP list generate alerts (new entries and status changes, with old → new detail). All vendors' MIP movements remain visible on the dashboard; they are deliberately excluded from email/Webex because the full list churns daily.
 
 ## ND-iTC
 

--- a/emailer.py
+++ b/emailer.py
@@ -7,8 +7,8 @@ Features:
     - Cisco-relevant alerts tagged and sorted to top (Tier 1)
     - Kind label promoted to front of each alert line
     - CSfC Capability Package changes show direct PDF link prominently
-    - Tier-sorted output: Cisco/NDcPP > NIST/standards > general
-  - Weekly digest covering NIAP, CC Portal, CCTL labs, CSfC, CC Crypto, NIST
+    - Tier-sorted output: Cisco/NDcPP > standards > general
+  - Weekly digest covering NIAP, CC Portal, CCTL labs, CSfC, CC Crypto
   - Immediate alert email (send_alert_email) for same-day keyword matches
   - Structured logging
   - Generic webhook / MS Teams delivery via send_webhook_alert()
@@ -62,9 +62,9 @@ _TIER2_KEYWORDS = {
     kw.lower() for kw in [
         "FIPS 140-3", "FIPS 186-4", "FIPS 186-5", "SP 800-131A",
         "FIPS 203", "FIPS 204", "FIPS 205",
-        "SP 800-57", "NIST IR 8547",
+        "SP 800-57",
         "ML-KEM", "ML-DSA", "SLH-DSA", "post-quantum", "PQC migration",
-        "CMVP", "CAVP", "algorithm transition", "CCDB-018",
+        "algorithm transition", "CCDB-018",
     ]
 }
 
@@ -76,7 +76,7 @@ def _is_cisco_relevant(alert: dict) -> bool:
 
 
 def _alert_tier(alert: dict) -> int:
-    """Return sort tier: 1 = Cisco/NDcPP direct, 2 = standards/NIST, 3 = general."""
+    """Return sort tier: 1 = Cisco/NDcPP direct, 2 = standards, 3 = general."""
     if _is_cisco_relevant(alert):
         return 1
     hits = {kw.lower() for kw in alert.get("matched_keywords", [])}
@@ -128,10 +128,6 @@ _CHANGE_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("updated",        "NIAP PP"): "An existing Protection Profile has been revised. Products in evaluation against it may be affected.",
     # Technical Decisions
     ("new",            "NIAP TD"): "A new NIAP Technical Decision (TD) has been issued. TDs clarify how a specific requirement in a Protection Profile should be interpreted by labs and vendors.",
-    # NIST / standards
-    ("publication",    "NIST"):  "A new or updated NIST cryptography publication has appeared. NIST standards often drive future Common Criteria and CSfC requirements.",
-    ("news",           "NIST"):  "New content has appeared on the NIST CSRC website (news, FIPS, CMVP, or post-quantum standards).",
-    ("updated",        "NIST"):  "A NIST standards document has been revised. Review the link for what changed.",
     # CSfC
     ("updated", "CSfC Component Selections"): (
         "NSA has updated a Component Selection document. "
@@ -176,7 +172,7 @@ def _describe_change(kind: str, source: str) -> str:
 
     Args:
         kind:   The change kind string (e.g. "new_cert", "sunset", "updated").
-        source: The source label (e.g. "NIAP PP", "NIST: fips", "CCTL Labs").
+        source: The source label (e.g. "NIAP PP", "CCTL Labs").
 
     Returns:
         A single sentence suitable for appending to a Webex or email alert.
@@ -205,7 +201,7 @@ def _format_alert_lines(alerts: list[dict], max_items: int = 15) -> list[str]:
     """Format alert objects into Markdown lines for Webex / webhook.
 
     Improvements for Cisco engineers:
-    - Alerts sorted by tier: Cisco-relevant first, then NIST/standards, then general.
+    - Alerts sorted by tier: Cisco-relevant first, then standards, then general.
     - Cisco-relevant alerts prefixed with a blue tag.
     - Kind label promoted to the front of each line (bold, uppercase).
     - CSfC Capability Package changes surface the direct PDF URL prominently.
@@ -259,7 +255,7 @@ def send_webex_alert(alerts: list[dict]) -> None:
     Message structure:
       - Header with total count and tier breakdown summary
       - Tier 1 (Cisco-relevant) alerts listed first
-      - Tier 2 (standards/NIST) next
+      - Tier 2 (standards) next
       - Tier 3 (general) last
       - Dashboard link footer
     """
@@ -279,7 +275,7 @@ def send_webex_alert(alerts: list[dict]) -> None:
     if tier_counts[1]:
         tier_parts.append(f"🔵 {tier_counts[1]} Cisco-relevant")
     if tier_counts[2]:
-        tier_parts.append(f"📐 {tier_counts[2]} standards/NIST")
+        tier_parts.append(f"📐 {tier_counts[2]} standards")
     if tier_counts[3]:
         tier_parts.append(f"📋 {tier_counts[3]} general")
 
@@ -566,53 +562,6 @@ def build_email_html(weekly_diff: dict) -> str:
             rows.append(_row(label, txt, "#60A5FA", "#12102E"))
     parts.append(_section("CC Crypto Catalog & Working Group", rows))
 
-    # ── NIST CSRC ────────────────────────────────────────────────────────────
-    nist = weekly_diff.get("nist", {})
-    rows = []
-    # CMVP MIP structured changes (fix #27)
-    cmvp_mip = nist.get("cmvp_mip", {})
-    _cmvp_url = "https://csrc.nist.gov/projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list"
-    for item in cmvp_mip.get("added", [])[:5]:
-        name = item.get("Module Name") or item.get("name") or item.get("text", "")[:80]
-        vendor = item.get("Vendor") or item.get("vendor") or ""
-        status = item.get("Status") or item.get("status") or ""
-        label = f"{name}" + (f" ({vendor})" if vendor else "")
-        detail = f"Status: {status}" if status else "New to MIP list"
-        rows.append(_row("CMVP NEW",
-            f'<a href="{_cmvp_url}">{_esc(label)}</a><br><small>{_esc(detail)}</small>',
-            "#22D3EE", "#12102E"))
-    for item in cmvp_mip.get("status_changes", [])[:5]:
-        name = item.get("Module Name") or item.get("name") or item.get("text", "")[:80]
-        vendor = item.get("Vendor") or item.get("vendor") or ""
-        label = f"{name}" + (f" ({vendor})" if vendor else "")
-        detail = f"{item.get('old_status','?')} → {item.get('new_status','?')}"
-        rows.append(_row("CMVP STATUS",
-            f'<a href="{_cmvp_url}">{_esc(label)}</a><br><small>{_esc(detail)}</small>',
-            "#FBBF24", "#12102E"))
-    _nist_page_urls = {
-        "news": "https://csrc.nist.gov/news",
-        "fips": "https://csrc.nist.gov/publications/fips",
-        "pqc": "https://csrc.nist.gov/projects/post-quantum-cryptography",
-        "crypto_standards": "https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines",
-        "cmvp_validated": "https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules",
-    }
-    for page_key, page_diff in nist.get("pages", {}).items():
-        if page_key == "cmvp_mip":
-            continue
-        if not isinstance(page_diff, dict):
-            continue
-        for item in page_diff.get("added", [])[:3]:
-            page_url = item.get("href") or _nist_page_urls.get(page_key, "https://csrc.nist.gov/")
-            txt = _link(page_url, item.get("text", "")[:120])
-            rows.append(_row(f"NIST:{page_key[:7]}", txt, "#22D3EE", "#12102E"))
-    for feed_name, items in nist.get("feeds", {}).items():
-        for item in items[:5]:
-            link = item.get("link", "")
-            title = item.get("title", "")
-            txt = _link(link, title)
-            rows.append(_row("NIST FEED", txt, "#22D3EE", "#12102E"))
-    parts.append(_section("NIST CSRC — Standards, CMVP & PQC", rows))
-
     # ── ND-iTC (NIT RFIs & Allowed-With lists) ────────────────────────────
     nd = weekly_diff.get("nd_itc", {})
     nd_rfis = nd.get("nit_rfis", {})
@@ -777,7 +726,7 @@ def send_alert_email(alerts: list[dict]) -> None:
     tier_note = (
         f'<p style="margin:6px 0 0;font-size:0.8rem;opacity:0.85">'
         f'\U0001f535 {tier1_count} Cisco-relevant \u00b7 '
-        f'\U0001f4d0 {sum(1 for a in alerts if _alert_tier(a)==2)} standards/NIST \u00b7 '
+        f'\U0001f4d0 {sum(1 for a in alerts if _alert_tier(a)==2)} standards \u00b7 '
         f'\U0001f4cb {sum(1 for a in alerts if _alert_tier(a)==3)} general</p>'
     ) if tier1_count else ""
     dashboard_link = (
@@ -1401,12 +1350,11 @@ def send_readme_message() -> None:
         "| **ND-iTC** | NIT RFIs (ND-iTC Technical Decisions — distinct from NIAP TDs) and Allowed-With lists |\n"
         "| **CC Portal** | International CC news, Protection Profiles, and certified products |\n"
         "| **CCTL Labs** | New posts from accredited Common Criteria evaluation labs |\n"
-        "| **NIST CSRC** | Cryptography news, FIPS publications, CMVP, and post-quantum standards |\n\n"
-        "Runs automatically every day at **06:00 UTC / 01:00 ET** (adjusts for EDT in summer) and posts here only when something relevant is found.\n\n"
+                "Runs automatically every day at **06:00 UTC / 01:00 ET** (adjusts for EDT in summer) and posts here only when something relevant is found.\n\n"
         "---\n\n"
         "## Dashboard Navigation\n\n"
         "The dashboard has three tabs:\n\n"
-        "- 🇺🇸 **US (NIAP / CSfC / NIST)** — All NIAP, CSfC, NIST, CC Portal, and CCTL cards\n"
+        "- 🇺🇸 **US (NIAP / CSfC)** — All NIAP, CSfC, CC Portal, and CCTL cards\n"
         "- 🌐 **NATO NIAPCL** — Changes to the NATO Information Assurance Product Catalogue\n"
         "- 🇪🇺 **EU (EUCC)** — Changes to EUCC requirements and certificates from ENISA\n\n"
         "---\n\n"
@@ -1417,7 +1365,7 @@ def send_readme_message() -> None:
         "---\n\n"
         "## Questions?\n\n"
         "Click any direct link in an alert — it goes straight to the source page "
-        "(NIAP, NIST, NSA, NATO, ENISA). No login required."
+        "(NIAP, NSA, NATO, ENISA). No login required."
     )
 
     payload = {"roomId": room_id, "markdown": msg}
@@ -1431,91 +1379,6 @@ def send_readme_message() -> None:
         log.info("[Webex] README posted successfully (id=%s). Pin it in the space.", resp.json().get("id"))
     else:
         log.error("[Webex] Failed to post README: %s %s", resp.status_code, resp.text)
-
-
-# ---------------------------------------------------------------------------
-# NIST CMVP MIP notification (fix #27)
-# ---------------------------------------------------------------------------
-
-def send_nist_cmvp_webex(cmvp_mip: dict) -> None:
-    """Post a Webex notification for CMVP Modules-in-Process additions and status changes.
-
-    Fires unconditionally whenever new modules are added to the CMVP MIP list
-    or existing modules change status (e.g. 'Review Pending' -> 'In Review').
-    This mirrors the send_new_tds_webex pattern for NIAP TDs.
-
-    Args:
-        cmvp_mip: The cmvp_mip sub-dict from diff["nist"]["cmvp_mip"],
-                  containing "added" and "status_changes" lists.
-    """
-    token = config.WEBEX_BOT_TOKEN
-    room_id = config.WEBEX_ROOM_ID
-    if not token or not room_id:
-        log.debug("[Webex] Bot token or Room ID not configured — skipping CMVP MIP notification.")
-        return
-
-    added = cmvp_mip.get("added", [])
-    status_changes = cmvp_mip.get("status_changes", [])
-    if not added and not status_changes:
-        return
-
-    mip_url = (
-        "https://csrc.nist.gov/projects/cryptographic-module-validation-program"
-        "/modules-in-process/modules-in-process-list"
-    )
-
-    lines = []
-
-    if added:
-        lines.append(f"### U0001f195 {len(added)} New Module(s) on CMVP MIP List")
-        for item in added:
-            name = item.get("Module Name") or item.get("name") or item.get("text", "Unknown module")
-            vendor = item.get("Vendor") or item.get("vendor") or ""
-            status = item.get("Status") or item.get("status") or ""
-            label = f"{name}" + (f" ({vendor})" if vendor else "")
-            status_str = f" — Status: *{status}*" if status else ""
-            lines.append(f"**[CMVP NEW]** [{label}]({mip_url}){status_str}")
-
-    if status_changes:
-        lines.append(f"### U0001f504 {len(status_changes)} Module Status Change(s)")
-        for item in status_changes:
-            name = item.get("Module Name") or item.get("name") or item.get("text", "Unknown module")
-            vendor = item.get("Vendor") or item.get("vendor") or ""
-            old_s = item.get("old_status", "?")
-            new_s = item.get("new_status", "?")
-            label = f"{name}" + (f" ({vendor})" if vendor else "")
-            lines.append(f"**[CMVP STATUS]** [{label}]({mip_url})\n  ↳ {old_s} → {new_s}")
-
-    total = len(added) + len(status_changes)
-    header = (
-        f"## U0001f510 NIST CMVP — {total} Module{{'s' if total != 1 else ''}} in Process Update{{'s' if total != 1 else ''}}\n"
-        f"_CC Pulse detected CMVP Modules-in-Process changes._\n"
-    )
-    footer = f"\n\n[View CMVP MIP List]({mip_url}) · [Full dashboard](https://kr15tyk.github.io/CC-pulse/cc_dashboard.html)"
-
-    body = "\n\n".join(lines)
-    payload = json.dumps({
-        "roomId": room_id,
-        "markdown": header + body + footer,
-    }).encode("utf-8")
-
-    req = urllib.request.Request(
-        "https://webexapis.com/v1/messages",
-        data=payload,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
-        },
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            log.info(
-                "[Webex] CMVP MIP notification sent: %d added, %d status changes (HTTP %d).",
-                len(added), len(status_changes), resp.status,
-            )
-    except urllib.error.URLError as exc:
-        log.warning("[Webex] Failed to send CMVP MIP notification: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -1660,19 +1523,13 @@ def send_daily_status_email(diff: dict, run_date: str = "") -> None:
     nato_adds  = diff.get("nato", {}).get("cisco_added", [])
     eucc_adds  = diff.get("eucc", {}).get("cisco_added", [])
 
-    nist_news = sum(
-        len(v.get("added", [])) for v in diff.get("nist", {}).get("pages", {}).values()
-        if isinstance(v, dict)
-    ) + sum(len(v) for v in diff.get("nist", {}).get("feeds", {}).values()) + \
-        len(diff.get("nist", {}).get("cmvp_mip", {}).get("added", [])) + \
-        len(diff.get("nist", {}).get("cmvp_mip", {}).get("status_changes", []))
     cc_crypto_new = sum(
         len(v.get("added", [])) for v in diff.get("cc_crypto", {}).get("pages", {}).values()
         if isinstance(v, dict)
     )
     niap_pp_changes = len(diff.get("niap", {}).get("pps", {}).get("added", [])) + \
                       len(diff.get("niap", {}).get("pps", {}).get("sunset_changes", []))
-    total_changes = len(alerts) + len(new_tds) + len(new_certs) + len(nato_adds) + len(eucc_adds) + nist_news + cc_crypto_new + niap_pp_changes
+    total_changes = len(alerts) + len(new_tds) + len(new_certs) + len(nato_adds) + len(eucc_adds) + cc_crypto_new + niap_pp_changes
     unhealthy_sources = {
         source: health for source, health in diff.get("source_health", {}).items()
         if health.get("status") in ("stale", "failed")
@@ -1713,8 +1570,7 @@ def send_daily_status_email(diff: dict, run_date: str = "") -> None:
         if new_certs: lines_detail.append(f"{len(new_certs)} new Cisco NDcPP cert(s)")
         if nato_adds: lines_detail.append(f"{len(nato_adds)} new Cisco NATO listing(s)")
         if eucc_adds: lines_detail.append(f"{len(eucc_adds)} new Cisco EUCC cert(s)")
-        if nist_news: lines_detail.append(f"{nist_news} NIST update(s) (news/FIPS/CMVP)")
-        if cc_crypto_new: lines_detail.append(f"{cc_crypto_new} CC Crypto publication(s)")
+                if cc_crypto_new: lines_detail.append(f"{cc_crypto_new} CC Crypto publication(s)")
         if niap_pp_changes: lines_detail.append(f"{niap_pp_changes} new/updated NIAP PP(s)")
         body_detail  = ("<p style='margin:0 0 12px;color:#94a3b8;font-size:14px;'>"
                         "CC Pulse detected new activity and sent the appropriate alerts:"

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ KEEP_SNAPSHOTS = 30  # days
 
 DOMAIN_KEYS = (
     "niap", "cc_portal", "cctl_labs", "csfc",
-    "cc_crypto", "nist", "nato", "eucc", "nd_itc",
+    "cc_crypto", "nato", "eucc", "nd_itc",
 )
 
 DOMAIN_LABELS = {
@@ -99,7 +99,6 @@ DOMAIN_LABELS = {
     "cctl_labs": "CCTL Labs",
     "csfc": "CSfC",
     "cc_crypto": "CC Crypto",
-    "nist": "NIST CSRC",
     "nato": "NATO NIAPCL",
     "eucc": "EUCC / ENISA",
     "nd_itc": "ND-iTC",
@@ -240,7 +239,6 @@ def _source_health_checks(snapshot: dict) -> dict[str, list[dict]]:
     cctl_labs = snapshot.get("cctl_labs", {})
     csfc = snapshot.get("csfc", {})
     cc_crypto = snapshot.get("cc_crypto", {})
-    nist = snapshot.get("nist", {})
     nato = snapshot.get("nato", {})
     eucc = snapshot.get("eucc", {})
 
@@ -272,11 +270,6 @@ def _source_health_checks(snapshot: dict) -> dict[str, list[dict]]:
             {"name": "publications", "observed": len(
                 cc_crypto.get("pages", {}).get("publications", [])
             ), "minimum": config.SANITY_MIN_CC_CRYPTO_PUBS},
-        ],
-        "nist": [
-            {"name": "CSRC news items", "observed": len(
-                nist.get("pages", {}).get("news", [])
-            ), "minimum": config.SANITY_MIN_NIST_NEWS},
         ],
         "nato": [
             {"name": "NIAPCL products", "observed": len(
@@ -647,7 +640,6 @@ def _empty_snapshot() -> dict:
         "cctl_labs": {},
         "csfc":      {"pages": {}, "capability_package_headers": {}, "feeds": {}},
         "cc_crypto": {"pages": {}},
-        "nist":      {"pages": {}, "cmvp_mip": {"added": [], "removed": [], "status_changes": []}, "feeds": {}},
         "nato":      {"pages": {}, "cisco_added": [], "cisco_removed": []},
         "eucc":      {"pages": {}, "cisco_added": [], "cisco_removed": []},
         "nd_itc":    {"nit_rfis": [], "nit_rfis_archived": [],
@@ -789,16 +781,7 @@ def _fire_alerts(diff: dict, emailer) -> None:
         )
         emailer.send_niap_news_webex(niap_content_changes)
 
-    # -- NIST CMVP MIP changes (fix #27) ------------------------------------------
-    cmvp_mip = diff.get("nist", {}).get("cmvp_mip", {})
-    if cmvp_mip.get("added") or cmvp_mip.get("status_changes"):
-        log.info(
-            "%d CMVP MIP addition(s), %d status change(s) — sending Webex notification...",
-            len(cmvp_mip.get("added", [])), len(cmvp_mip.get("status_changes", [])),
-        )
-        emailer.send_nist_cmvp_webex(cmvp_mip)
-
-        # -- Daily status heartbeat (always fires unless DRY_RUN) ----------------
+    # -- Daily status heartbeat (always fires unless DRY_RUN) ----------------
     emailer.send_daily_status_email(diff)
 
 # ── Run modes ─────────────────────────────────────────────────────────────────────────────────────
@@ -854,7 +837,7 @@ def run_daily(output_dir: str = None) -> None:
             if isinstance(obj, dict):
                 return {k: _clear_lists(v) for k, v in obj.items()}
             return obj
-        for section in ("niap", "cc_portal", "cctl_labs", "csfc", "cc_crypto", "nist", "nato", "eucc"):  # fix #23
+        for section in ("niap", "cc_portal", "cctl_labs", "csfc", "cc_crypto", "nato", "eucc"):  # fix #23
             if section in diff:
                 diff[section] = _clear_lists(diff[section])
         diff["alerts"] = []
@@ -929,8 +912,7 @@ def run_merge(partial_dir: str = "snapshots/partial", output_dir: str = None) ->
         "cctl_labs": domain_data.get("cctl_labs", {}),
         "csfc":      domain_data.get("csfc", {}),
         "cc_crypto": domain_data.get("cc_crypto", {}),
-        "nist":      domain_data.get("nist", {}),
-        "nato":      domain_data.get("nato", {}),
+                "nato":      domain_data.get("nato", {}),
         "eucc":      domain_data.get("eucc", {}),
         "nd_itc":    domain_data.get("nd_itc", {}),
     }
@@ -968,7 +950,7 @@ def run_merge(partial_dir: str = "snapshots/partial", output_dir: str = None) ->
             if isinstance(obj, dict):
                 return {k: _clear_lists(v) for k, v in obj.items()}
             return obj
-        for section in ("niap", "cc_portal", "cctl_labs", "csfc", "cc_crypto", "nist", "nato", "eucc"):
+        for section in ("niap", "cc_portal", "cctl_labs", "csfc", "cc_crypto", "nato", "eucc"):
             if section in diff:
                 diff[section] = _clear_lists(diff[section])
         diff["alerts"] = []


### PR DESCRIPTION
Removes all NIST, CAVP, and CMVP-specific monitoring, diffing, and notification logic from the collector/differ/emailer/dashboard pipeline, since these standards are no longer in scope for tracking.

Changes:
- config.py, collector.py, differ.py: confirmed no NIST-specific domain logic (already clean or verified)
- - emailer.py: removed NIST/CMVP Webex notification path; trimmed CAVP/CMVP keywords from tier-2 list
- - dashboard.py: removed NIST cards, sources-group entry, stat blocks, RSS section, filter button, and renamed NIAP/CSfC/NIST tab label to NIAP/CSfC
- - README.md: removed NIST CSRC row from coverage table
- - docs/MONITORING.md: removed NIST-specific coverage details, kept shared CC Crypto row
- - docs/NOTIFICATIONS.md: removed CMVP Modules-in-Process section, renamed Standards/NIST tier label to Standards
- - docs/DEVELOPMENT.md: no changes needed (no NIST references)
- - .github/workflows/cc_pulse.yml: removed orphaned `nist` domain from the collection matrix
Note: tests/ directory and dashboard regeneration were intentionally left out of scope for this PR pending follow-up.