### PR TITLE
fix: URL-encode CSfC selection doc links to prevent broken notificati…

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -23,7 +23,7 @@ import feedparser
 import requests
 from curl_cffi import requests as curl_requests
 from bs4 import BeautifulSoup
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote
 from datetime import datetime, timezone
 
 import config
@@ -1304,7 +1304,7 @@ def _scrape_csfc_selection_links(soup) -> dict:
         # Build absolute URL if needed
         if href.startswith("/"):
             href = config.CSFC_BASE + href
-        results[heading] = href
+        results[heading] = quote(href, safe=":/?=&%")
     log.debug("[CSfC Selections] Scraped %d selection links from Components List page.", len(results))
     return results
 


### PR DESCRIPTION
…on links

The href scraped from NSA's Components List page (_scrape_csfc_selection_links) is preserved verbatim, but NSA's own anchor hrefs contain literal unencoded spaces (e.g. ".../CSfC Selections Updates 2026/..."). When this raw URL is placed into plain-text/markdown notification messages (Webex, RSS, dashboard), auto-linkers stop at the first space, truncating the clickable link and leaving the rest as plain text.

Fix: URL-encode the href with urllib.parse.quote (safe=":/?=&%") right before storing it, so spaces become %20 while the scheme, existing %-encoded sequences, and query string (including the ?ver= cache-busting token) are preserved.