### PR TITLE
Add "updated" category for CSfC APL listing changes

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -212,14 +212,20 @@ def _build_history(n: int = 90) -> list:
         # CSfC Components List and Announcements changes
         for page_key in ("apl", "announcements"):
             page_diff = d.get("csfc", {}).get("pages", {}).get(page_key, {})
-            for kind in ("added", "removed"):
+            for kind in ("added", "removed", "updated"):
                 for item in page_diff.get(kind, []):
                     label = "Component" if page_key == "apl" else "Announcement"
+                    if kind == "updated":
+                        change_kind = "updated"
+                        title = f"CSfC {label} updated: {(item.get('text') or '')[:80]}"
+                    else:
+                        change_kind = "new" if kind == "added" else "removed"
+                        title = f"CSfC {label}: {(item.get('text') or '')[:80]}"
                     entries.append({
                         "date": date,
                         "category": "csfc_change",
-                        "kind": "new" if kind == "added" else "removed",
-                        "title": f"CSfC {label}: {(item.get('text') or '')[:80]}",
+                        "kind": change_kind,
+                        "title": title,
                         "detail": "",
                         "url": item.get("href") or (
                             "https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/"
@@ -261,7 +267,7 @@ def _section_daily_counts(diffs: list, section_key: str) -> list:
             csfc = d.get("csfc", {})
             n = sum(1 for cp in csfc.get("selection_links", {}).values() if cp.get("changed"))
             n += sum(
-                len(page_diff.get("added", [])) + len(page_diff.get("removed", []))
+                len(page_diff.get("added", [])) + len(page_diff.get("removed", [])) + len(page_diff.get("updated", []))
                 for page_key, page_diff in csfc.get("pages", {}).items()
                 if page_key in ("apl", "announcements") and isinstance(page_diff, dict)
             )
@@ -915,6 +921,12 @@ DASHBOARD_TEMPLATE = """
         <div class="item-row" data-source="csfc" data-kind="removed">
           <a class="item-link" href="{{ (item.href or (config_csfc_components_url if page_key == 'apl' else config_csfc_announcements_url)) | safe_url }}" target="_blank">{{ item.text }}</a>
           <span class="item-meta">{% if page_key == 'apl' %}component removed{% else %}announcement removed{% endif %}</span>
+        </div>
+        {% endfor %}
+        {% for item in page_diff.get('updated', []) %}
+        <div class="item-row" data-source="csfc" data-kind="updated">
+          <a class="item-link" href="{{ (item.href or (config_csfc_components_url if page_key == 'apl' else config_csfc_announcements_url)) | safe_url }}" target="_blank">{{ item.text }}</a>
+          <span class="item-meta">{% if page_key == 'apl' %}component updated{% else %}announcement updated{% endif %}</span>
         </div>
         {% endfor %}
       {% endif %}
@@ -1614,7 +1626,7 @@ def render_dashboard(diff: dict, output_dir: str = "docs") -> None:
     csfc_total      = sum(1 for cp in csfc_diff.get("selection_links", {}).values()
                           if cp.get("changed"))
     csfc_total     += sum(
-        len(page_diff.get("added", [])) + len(page_diff.get("removed", []))
+        len(page_diff.get("added", [])) + len(page_diff.get("removed", [])) + len(page_diff.get("updated", []))
         for page_key, page_diff in csfc_diff.get("pages", {}).items()
         if page_key in ("apl", "announcements") and isinstance(page_diff, dict)
     )

--- a/dashboard.py
+++ b/dashboard.py
@@ -495,7 +495,7 @@ DASHBOARD_TEMPLATE = """
       <div class="sources-group">
         <div class="sources-group-title">🇳🇮 CSfC (Commercial Solutions for Classified)</div>
         <div class="sources-item"><span class="src-label">Main:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/" target="_blank" rel="noopener">nsa.gov &mdash; CSfC Home</a></div>
-        <div class="sources-item"><span class="src-label">Components List:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/" target="_blank" rel="noopener">nsa.gov &mdash; CSfC APL Components</a></div>
+        <div class="sources-item"><span class="src-label">Components List:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/" target="_blank" rel="noopener">nsa.gov &mdash; CSfC Components List</a></div>
         <div class="sources-item"><span class="src-label">Capability Packages:</span><a href="https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Capability-Packages/" target="_blank" rel="noopener">nsa.gov &mdash; Capability Packages</a></div>
         <div class="sources-item"><span class="src-label">NSA Advisories (RSS):</span><a href="https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&amp;Site=1282&amp;max=20" target="_blank" rel="noopener">nsa.gov &mdash; NSA News RSS</a></div>
         <div class="sources-item"><span class="src-label">CISA Alerts (RSS):</span><a href="https://www.cisa.gov/cybersecurity-advisories/all.xml" target="_blank" rel="noopener">cisa.gov &mdash; All Advisories</a></div>

--- a/differ.py
+++ b/differ.py
@@ -294,6 +294,18 @@ def flag_alerts(diff: Snapshot) -> list[dict]:
                 additional_keywords=vendor_keywords,
             )
 
+        for item in page_diff.get("updated", []):
+            vendor_keywords = config.CISCO_VENDOR_KEYWORDS if page_key == "apl" else []
+            _add_text(
+                "CSfC APL" if page_key == "apl" else f"CSfC: {page_key}",
+                "updated",
+                item.get("text", ""),
+                url=item.get("href") or item.get("link") or _csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL),
+                detail=f"Listing updated on CSfC {page_key.replace('_', ' ')} page",
+                tab="us",
+                additional_keywords=vendor_keywords,
+            )
+
     # CC Crypto Catalog page changes — fire unconditionally for publications (fix #27)
     # The publications page is curated CC crypto content; all new items are relevant.
     _cc_crypto_urls = {
@@ -760,6 +772,43 @@ def _diff_pages(old_pages: dict, new_pages: dict) -> dict:
             result[page_key] = {"added": added, "removed": removed}
     return result
 
+
+# -- CSfC APL diff helper (keyed by stable link, not text prefix) ------------
+def _diff_csfc_apl(old_items: list, new_items: list) -> dict:
+    """Diff CSfC Components List (APL) entries, keyed by their NIAP link.
+
+    _diff_pages() keys purely on the first 120 chars of display text, so an
+    edit to an existing listing's wording (a cert-date tweak, a description
+    reformat) with the underlying product/VID unchanged shows up as a
+    spurious removed+added pair. APL records carry a stable href to the
+    underlying NIAP product page (collector._parse_csfc_apl_structured), so
+    key on that instead (falling back to the text prefix for any record
+    without one) and report same-key text changes as "updated".
+    """
+    old_by_key = {
+        _record_key(item, url_field="href", text_field="text"): item
+        for item in old_items
+    }
+    new_by_key = {
+        _record_key(item, url_field="href", text_field="text"): item
+        for item in new_items
+    }
+    old_keys = set(old_by_key)
+    new_keys = set(new_by_key)
+
+    added = [new_by_key[k] for k in new_keys - old_keys]
+    removed = [old_by_key[k] for k in old_keys - new_keys]
+    updated = []
+    for k in old_keys & new_keys:
+        old_item = old_by_key[k]
+        new_item = new_by_key[k]
+        if (old_item.get("text") or "") != (new_item.get("text") or ""):
+            changed = copy.deepcopy(new_item)
+            changed["_old_text"] = old_item.get("text") or ""
+            updated.append(changed)
+
+    return {"added": added, "removed": removed, "updated": updated}
+
 # -- Generic feed diff helper ---------------------------------------------------
 def _diff_feeds(old_feeds: dict, new_feeds: dict, categorize: bool = False) -> dict:
     """Diff two {feed_name: [items]} dicts by id/title/link key."""
@@ -1199,6 +1248,10 @@ def merge_weekly_diffs(diffs: list[Snapshot]) -> Snapshot:
                     weekly["csfc"]["pages"][page_key] = {"added": []}
                 weekly["csfc"]["pages"][page_key]["added"] = merge_lists(
                     weekly["csfc"]["pages"][page_key]["added"], page_diff["added"])
+            if "updated" in page_diff:
+                weekly["csfc"]["pages"][page_key]["updated"] = merge_lists(
+                    weekly["csfc"]["pages"][page_key].get("updated", []),
+                    page_diff["updated"])
         for sel_name, sel_data in d.get("csfc", {}).get("selection_links", {}).items():
             weekly["csfc"]["selection_links"][sel_name] = sel_data
 
@@ -1253,7 +1306,14 @@ def merge_weekly_diffs(diffs: list[Snapshot]) -> Snapshot:
 # -- CSfC diff -----------------------------------------------------------------
 def diff_csfc(old_csfc: Snapshot, new_csfc: Snapshot) -> Snapshot:
     """Diff two CSfC snapshots."""
-    pages = _diff_pages(old_csfc.get("pages", {}), new_csfc.get("pages", {}))
+    old_pages = old_csfc.get("pages", {})
+    new_pages = new_csfc.get("pages", {})
+    non_apl_old = {k: v for k, v in old_pages.items() if k != "apl"}
+    non_apl_new = {k: v for k, v in new_pages.items() if k != "apl"}
+    pages = _diff_pages(non_apl_old, non_apl_new)
+    apl_diff = _diff_csfc_apl(old_pages.get("apl", []), new_pages.get("apl", []))
+    if apl_diff["added"] or apl_diff["removed"] or apl_diff["updated"]:
+        pages["apl"] = apl_diff
     selection_links = _diff_selection_links(
         old_csfc.get("selection_links", {}),
         new_csfc.get("selection_links", {}),
@@ -1266,9 +1326,10 @@ def diff_csfc(old_csfc: Snapshot, new_csfc: Snapshot) -> Snapshot:
     page_changes = sum(len(v.get("added", [])) for v in pages.values())
     sel_changes = len(selection_links)
     feed_new = sum(len(v) for v in feeds.values())
+    apl_updated = len(apl_diff["updated"])
     log.info(
-        "[CSfC Diff] page-items-added:%d selection-link-changes:%d feed-new:%d",
-        page_changes, sel_changes, feed_new,
+        "[CSfC Diff] page-items-added:%d apl-updated:%d selection-link-changes:%d feed-new:%d",
+        page_changes, apl_updated, sel_changes, feed_new,
     )
     return {"pages": pages, "selection_links": selection_links, "feeds": feeds}
 

--- a/differ.py
+++ b/differ.py
@@ -263,7 +263,7 @@ def flag_alerts(diff: Snapshot) -> list[dict]:
                 tab="us",
             )
 
-    # CSfC APL page changes — new items on the Components List page
+    # CSfC Components List page changes — new items on the Components List page
     _csfc_page_urls = {
         "apl":           config.CSFC_PRODUCT_LIST_URL,
         "home":          config.CSFC_BASE + "/Resources/Commercial-Solutions-for-Classified-Program/",
@@ -274,7 +274,7 @@ def flag_alerts(diff: Snapshot) -> list[dict]:
         for item in page_diff.get("added", []):
             vendor_keywords = config.CISCO_VENDOR_KEYWORDS if page_key == "apl" else []
             _add_text(
-                "CSfC APL" if page_key == "apl" else f"CSfC: {page_key}",
+                "CSfC Components List" if page_key == "apl" else f"CSfC: {page_key}",
                 "new_cert" if page_key == "apl" else "new",
                 item.get("text", ""),
                 url=(_csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL) if page_key == "apl" else item.get("href") or item.get("link") or _csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL)),
@@ -285,7 +285,7 @@ def flag_alerts(diff: Snapshot) -> list[dict]:
         for item in page_diff.get("removed", []):
             vendor_keywords = config.CISCO_VENDOR_KEYWORDS if page_key == "apl" else []
             _add_text(
-                "CSfC APL" if page_key == "apl" else f"CSfC: {page_key}",
+                "CSfC Components List" if page_key == "apl" else f"CSfC: {page_key}",
                 "removed",
                 item.get("text", ""),
                 url=(_csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL) if page_key == "apl" else item.get("href") or item.get("link") or _csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL)),
@@ -297,7 +297,7 @@ def flag_alerts(diff: Snapshot) -> list[dict]:
         for item in page_diff.get("updated", []):
             vendor_keywords = config.CISCO_VENDOR_KEYWORDS if page_key == "apl" else []
             _add_text(
-                "CSfC APL" if page_key == "apl" else f"CSfC: {page_key}",
+                "CSfC Components List" if page_key == "apl" else f"CSfC: {page_key}",
                 "updated",
                 item.get("text", ""),
                 url=item.get("href") or item.get("link") or _csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL),
@@ -773,9 +773,9 @@ def _diff_pages(old_pages: dict, new_pages: dict) -> dict:
     return result
 
 
-# -- CSfC APL diff helper (keyed by stable link, not text prefix) ------------
+# -- CSfC Components List diff helper (keyed by stable link, not text prefix) ------------
 def _diff_csfc_apl(old_items: list, new_items: list) -> dict:
-    """Diff CSfC Components List (APL) entries, keyed by their NIAP link.
+    """Diff CSfC Components List entries, keyed by their NIAP link.
 
     _diff_pages() keys purely on the first 120 chars of display text, so an
     edit to an existing listing's wording (a cert-date tweak, a description

--- a/emailer.py
+++ b/emailer.py
@@ -113,7 +113,7 @@ def _kind_label(kind: str) -> str:
 _CHANGE_DESCRIPTIONS: dict[tuple[str, str], str] = {
     # New certifications
     ("new_cert",       "NIAP"):  "A product has been newly certified on the NIAP Validated Products List.",
-    ("new_cert",       "CSfC"):  "A product has been added to the NSA Commercial Solutions for Classified (CSfC) Approved Products List.",
+    ("new_cert",       "CSfC"):  "A product has been added to the NSA Commercial Solutions for Classified (CSfC) Components List.",
     ("new_cert",       "NATO"):  "A product has received a new listing on the NATO Information Assurance Product Catalogue (NIAPCL).",
     ("new_cert",       "EUCC"):  "A product has received a new EU Common Criteria (EUCC) certificate from ENISA.",
     # Products entering evaluation
@@ -136,8 +136,8 @@ _CHANGE_DESCRIPTIONS: dict[tuple[str, str], str] = {
         "Review the Components List page to see what changed and check whether any "
         "approved products relevant to your program have been added or removed."
     ),
-    ("updated", "CSfC APL"): (
-        "An existing CSfC Components List (APL) entry was revised \u2014 the underlying "
+    ("updated", "CSfC Components List"): (
+        "An existing CSfC Components List entry was revised \u2014 the underlying "
         "product/VID is unchanged, but the listing text (description, cert date, etc.) "
         "was edited. This is not a new product being added or an approved product "
         "losing approval."
@@ -539,12 +539,12 @@ def build_email_html(weekly_diff: dict) -> str:
     for page_key, page_diff in csfc.get("pages", {}).items():
         for item in page_diff.get("added", [])[:3]:
             page_url = (_csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL) if page_key == "apl" else item.get("href") or item.get("link") or _csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL))
-            label    = "APL" if page_key == "apl" else page_key[:8]
+            label     = "Components List" if page_key == "apl" else page_key[:8]
             txt      = _link(page_url, item.get("text", "")[:120])
             rows.append(_row(f"NSA:{label}", txt, "#60A5FA", "#12102E"))
         for item in page_diff.get("updated", [])[:3]:
             item_url = item.get("href") or item.get("link") or _csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL)
-            label    = "APL" if page_key == "apl" else page_key[:8]
+            label     = "Components List" if page_key == "apl" else page_key[:8]
             txt      = _link(item_url, item.get("text", "")[:120])
             rows.append(_row(f"NSA:{label}-UPD", txt, "#FBBF24", "#12102E"))
     for feed_name, items in csfc.get("feeds", {}).items():
@@ -553,7 +553,7 @@ def build_email_html(weekly_diff: dict) -> str:
             title = item.get("title", "")
             txt   = _link(link, title)
             rows.append(_row("ADVISORY", txt, "#60A5FA", "#12102E"))
-    parts.append(_section("CSfC — Capability Packages & APL", rows))
+    parts.append(_section("CSfC — Capability Packages & Components List", rows))
 
     # ── CC Crypto Catalog ──────────────────────────────────────────────────────
     cc_crypto = weekly_diff.get("cc_crypto", {})
@@ -1355,7 +1355,7 @@ def send_readme_message() -> None:
         "| Source | What's tracked |\n"
         "|---|---|\n"
         "| **NIAP** | Certified products (PCL), Protection Profiles, Technical Decisions, CCTLs, news/events |\n"
-        "| **CSfC / NSA** | Approved Products List and Component Selection documents |\n"
+        "| **CSfC / NSA** | Components List and Component Selection documents |\n"
         "| **NATO NIAPCL** | NATO Information Assurance Product Catalogue — certified products and components |\n"
         "| **EUCC / ENISA** | EU Common Criteria certification scheme — requirements and issued certificates |\n"
         "| **ND-iTC** | NIT RFIs (ND-iTC Technical Decisions — distinct from NIAP TDs) and Allowed-With lists |\n"

--- a/emailer.py
+++ b/emailer.py
@@ -136,6 +136,12 @@ _CHANGE_DESCRIPTIONS: dict[tuple[str, str], str] = {
         "Review the Components List page to see what changed and check whether any "
         "approved products relevant to your program have been added or removed."
     ),
+    ("updated", "CSfC APL"): (
+        "An existing CSfC Components List (APL) entry was revised \u2014 the underlying "
+        "product/VID is unchanged, but the listing text (description, cert date, etc.) "
+        "was edited. This is not a new product being added or an approved product "
+        "losing approval."
+    ),
     ("updated",        "CSfC"):  "A CSfC Capability Package or Component Selection document has changed. These documents define the approved architectures for handling classified information.",
     ("advisory",       "CSfC"):  "A new CSfC advisory or policy document has been published by the NSA.",
     # CC Portal
@@ -536,6 +542,11 @@ def build_email_html(weekly_diff: dict) -> str:
             label    = "APL" if page_key == "apl" else page_key[:8]
             txt      = _link(page_url, item.get("text", "")[:120])
             rows.append(_row(f"NSA:{label}", txt, "#60A5FA", "#12102E"))
+        for item in page_diff.get("updated", [])[:3]:
+            item_url = item.get("href") or item.get("link") or _csfc_page_urls.get(page_key, config.CSFC_PRODUCT_LIST_URL)
+            label    = "APL" if page_key == "apl" else page_key[:8]
+            txt      = _link(item_url, item.get("text", "")[:120])
+            rows.append(_row(f"NSA:{label}-UPD", txt, "#FBBF24", "#12102E"))
     for feed_name, items in csfc.get("feeds", {}).items():
         for item in items[:3]:
             link  = item.get("link", "")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -185,3 +185,112 @@ def test_dashboard_renders_revised_announcement_and_policy(tmp_path):
     assert '<span class="card-count">2 alerts</span>' in html
     assert "2 alerts</div>" not in html
     assert "CSfC Component Selections: IPsec VPN Gateway" in html
+
+
+def test_csfc_counts_include_updated_bucket():
+    diff = {
+        "csfc": {
+            "selection_links": {},
+            "pages": {
+                "apl": {
+                    "added": [],
+                    "removed": [],
+                    "updated": [{"text": "Component listing revised"}],
+                },
+            },
+        },
+    }
+
+    assert dashboard._section_daily_counts([diff], "csfc") == [1]
+
+def test_history_includes_csfc_component_updated_entries(tmp_path):
+    old_dir = dashboard.config.DIFF_DIR
+    dashboard.config.DIFF_DIR = str(tmp_path)
+    try:
+        payload = {
+            "period_end": "2026-07-02T06:00:00+00:00",
+            "niap": {
+                "cisco_ndcpp": {"added": []},
+                "pps": {"added": [], "removed": []},
+                "tds": {"added": []},
+                "pcl_all": {"added": []},
+                "in_evaluation": {"added": [], "removed": []},
+            },
+            "nato": {"cisco_added": []},
+            "eucc": {"cisco_added": []},
+            "csfc": {
+                "selection_links": {},
+                "pages": {
+                    "apl": {
+                        "added": [],
+                        "removed": [],
+                        "updated": [{
+                            "text": "Cisco Secure Firewall listing revised",
+                            "href": "https://example.test/component",
+                        }],
+                    },
+                },
+            },
+            "nist": {"pages": {}},
+        }
+        (tmp_path / "2026-07-02_diff.json").write_text(json.dumps(payload))
+
+        history = dashboard._build_history()
+
+        updated_entries = [
+            h for h in history
+            if h["category"] == "csfc_change" and h["kind"] == "updated"
+        ]
+        assert len(updated_entries) == 1
+        assert "updated" in updated_entries[0]["title"].lower()
+        assert "Cisco Secure Firewall" in updated_entries[0]["title"]
+    finally:
+        dashboard.config.DIFF_DIR = old_dir
+
+def test_dashboard_renders_csfc_component_updated_item(tmp_path):
+    dashboard.config.DIFF_DIR = str(tmp_path / "diffs")
+    dashboard.config.STAGING_DIR = "docs/staging"
+    dashboard.config.WATCH_KEYWORDS = []
+    dashboard.config.NATO_NIAPCL_URL = "https://example.test/nato"
+    dashboard.config.EUCC_REQUIREMENTS_URL = "https://example.test/eucc"
+    dashboard.config.EUCC_CERTIFICATES_URL = "https://example.test/eucc-certs"
+    dashboard.config.CSFC_PRODUCT_LIST_URL = "https://example.test/csfc"
+    dashboard.config.CSFC_BASE = "https://example.test"
+    dashboard.config.CSFC_PAGES = {"announcements": "/announcements"}
+    diff = {
+        "period_start": "2026-07-01T00:00:00Z",
+        "period_end": "2026-07-02T00:00:00Z",
+        "niap": {
+            "pps": {}, "tds": {}, "cisco_ndcpp": {}, "pcl_all": {},
+            "in_evaluation": {},
+            "news": {key: [] for key in ("added", "revised", "deactivated", "reactivated", "removed")},
+            "events": {key: [] for key in ("added", "revised", "deactivated", "reactivated", "removed")},
+            "policies": {key: [] for key in ("added", "revised", "archived", "reactivated", "removed")},
+        },
+        "cc_portal": {"news": {"added": []}, "pps": {"added": []}, "products": {"added": []}},
+        "cctl_labs": {},
+        "csfc": {
+            "pages": {
+                "apl": {
+                    "added": [],
+                    "removed": [],
+                    "updated": [{
+                        "text": "Cisco Secure Firewall listing revised",
+                        "href": "https://example.test/component",
+                    }],
+                },
+            },
+            "selection_links": {},
+            "feeds": {},
+        },
+        "cc_crypto": {"pages": {}}, "nist": {"pages": {}},
+        "nato": {"pages": {}, "cisco_added": [], "cisco_removed": []},
+        "eucc": {"pages": {}, "cisco_added": [], "cisco_removed": []},
+        "alerts": [],
+    }
+
+    dashboard.render_dashboard(diff, output_dir=str(tmp_path))
+    html = (tmp_path / "cc_dashboard.html").read_text()
+
+    assert "Cisco Secure Firewall listing revised" in html
+    assert "component updated" in html

--- a/tests/test_differ.py
+++ b/tests/test_differ.py
@@ -645,3 +645,211 @@ class TestDiffNiapPclAll:
         result = differ.diff_niap_pcl_all(old, new)
         assert len(result["newly_archived"]) == 1
         assert result["added"] == []
+
+
+
+# ===========================================================================
+# _diff_csfc_apl -- link-keyed diff (avoids false removed+added on reformats)
+# ===========================================================================
+
+class TestDiffCsfcApl:
+
+    def test_new_link_is_added(self):
+        result = differ._diff_csfc_apl([], [{"href": "https://x/1", "text": "New component"}])
+        assert len(result["added"]) == 1
+        assert result["removed"] == []
+        assert result["updated"] == []
+
+    def test_missing_link_is_removed(self):
+        old = [{"href": "https://x/1", "text": "Old component"}]
+        result = differ._diff_csfc_apl(old, [])
+        assert len(result["removed"]) == 1
+        assert result["added"] == []
+        assert result["updated"] == []
+
+    def test_unchanged_entry_is_not_reported(self):
+        item = {"href": "https://x/1", "text": "Stable component"}
+        result = differ._diff_csfc_apl([item], [dict(item)])
+        assert result == {"added": [], "removed": [], "updated": []}
+
+    def test_text_reformat_on_same_link_is_updated_not_removed_added(self):
+        """The bug this helper fixes: a cosmetic listing edit (cert-date tweak,
+        description reformat) must not appear as a spurious removed+added pair."""
+        old = [{"href": "https://x/1", "text": "Cisco ASA 5500, VID 12345 -- certified Jan 2024"}]
+        new = [{"href": "https://x/1", "text": "Cisco ASA 5500 (VID 12345), cert. Jan 2024"}]
+        result = differ._diff_csfc_apl(old, new)
+        assert result["added"] == []
+        assert result["removed"] == []
+        assert len(result["updated"]) == 1
+        assert result["updated"][0]["_old_text"] == old[0]["text"]
+        assert result["updated"][0]["text"] == new[0]["text"]
+
+    def test_falls_back_to_text_prefix_when_no_href(self):
+        """Records without a stable href fall back to keying on the text prefix."""
+        old = [{"text": "Component without a link"}]
+        new = [{"text": "Component without a link"}]
+        result = differ._diff_csfc_apl(old, new)
+        assert result == {"added": [], "removed": [], "updated": []}
+
+    def test_different_link_same_text_prefix_is_added_and_removed(self):
+        """Two different products should never collapse into a single 'updated'."""
+        old = [{"href": "https://x/1", "text": "Component A"}]
+        new = [{"href": "https://x/2", "text": "Component A"}]
+        result = differ._diff_csfc_apl(old, new)
+        assert len(result["added"]) == 1
+        assert len(result["removed"]) == 1
+        assert result["updated"] == []
+
+
+# ===========================================================================
+# diff_csfc -- routes the "apl" page through _diff_csfc_apl(); other CSfC
+# pages keep the generic text-prefix diff
+# ===========================================================================
+
+class TestDiffCsfc:
+
+    def test_apl_reformat_is_updated_not_removed_added(self):
+        old_csfc = {"pages": {"apl": [{"href": "https://x/1", "text": "Old wording"}]}}
+        new_csfc = {"pages": {"apl": [{"href": "https://x/1", "text": "New wording"}]}}
+        result = differ.diff_csfc(old_csfc, new_csfc)
+        apl = result["pages"]["apl"]
+        assert apl["added"] == []
+        assert apl["removed"] == []
+        assert len(apl["updated"]) == 1
+
+    def test_non_apl_page_reformat_still_uses_generic_text_diff(self):
+        """Only the apl page gets link-keyed diffing; other CSfC pages are
+        unaffected by this change and keep their existing text-prefix behaviour."""
+        old_csfc = {"pages": {"announcements": [{"href": "https://x/a", "text": "Old wording"}]}}
+        new_csfc = {"pages": {"announcements": [{"href": "https://x/a", "text": "New wording"}]}}
+        result = differ.diff_csfc(old_csfc, new_csfc)
+        announcements = result["pages"]["announcements"]
+        assert len(announcements["added"]) == 1
+        assert len(announcements["removed"]) == 1
+        assert "updated" not in announcements
+
+    def test_apl_key_absent_when_no_changes(self):
+        old_csfc = {"pages": {"apl": [{"href": "https://x/1", "text": "Same"}]}}
+        new_csfc = {"pages": {"apl": [{"href": "https://x/1", "text": "Same"}]}}
+        result = differ.diff_csfc(old_csfc, new_csfc)
+        assert "apl" not in result["pages"]
+
+
+# ===========================================================================
+# flag_alerts -- CSfC "updated" bucket (this feature)
+# ===========================================================================
+
+class TestFlagAlertsCsfcUpdated:
+
+    def test_updated_csfc_apl_item_triggers_alert(self):
+        diff = _diff_with_alerts([])
+        diff["csfc"] = {
+            "selection_links": {},
+            "feeds": {},
+            "pages": {
+                "apl": {
+                    "added": [],
+                    "removed": [],
+                    "updated": [{"text": "CSfC listing revised: Cisco Secure Firewall", "href": "https://example.test/item"}],
+                },
+            },
+        }
+
+        alerts = differ.flag_alerts(diff)
+
+        updated_alerts = [a for a in alerts if a["kind"] == "updated" and a["source"] == "CSfC Components List"]
+        assert len(updated_alerts) == 1
+        assert updated_alerts[0]["url"] == "https://example.test/item"
+
+    def test_updated_item_url_falls_back_to_page_url_when_no_href(self):
+        diff = _diff_with_alerts([])
+        diff["csfc"] = {
+            "selection_links": {},
+            "feeds": {},
+            "pages": {
+                "apl": {
+                    "added": [],
+                    "removed": [],
+                    "updated": [{"text": "CSfC listing revised: Cisco Secure Firewall"}],
+                },
+            },
+        }
+
+        alerts = differ.flag_alerts(diff)
+
+        updated_alerts = [a for a in alerts if a["kind"] == "updated" and a["source"] == "CSfC Components List"]
+        assert len(updated_alerts) == 1
+        assert updated_alerts[0]["url"] == _cfg.CSFC_PRODUCT_LIST_URL
+
+    def test_missing_updated_key_does_not_break_flag_alerts(self):
+        """Backward compatibility: page diffs produced before this feature have
+        no 'updated' key at all. flag_alerts() must not raise on them."""
+        diff = _diff_with_alerts([])
+        diff["csfc"] = {
+            "selection_links": {},
+            "feeds": {},
+            "pages": {
+                "apl": {
+                    "added": [{"text": "New CSfC component added", "href": ""}],
+                    "removed": [],
+                },
+            },
+        }
+
+        alerts = differ.flag_alerts(diff)  # should not raise
+
+        assert any(a["kind"] == "new_cert" for a in alerts)
+        assert not any(a["kind"] == "updated" for a in alerts)
+
+
+# ===========================================================================
+# merge_weekly_diffs -- CSfC APL "updated" bucket merge behaviour
+# ===========================================================================
+
+class TestMergeWeeklyDiffsCsfcUpdated:
+
+    def _make_diff_with_apl_updated(self, updated_items=None):
+        return {
+            "niap": {
+                "pps": {"added": [], "removed": [], "sunset_changes": [], "status_changes": []},
+                "tds": {"added": [], "removed": []},
+                "cisco_ndcpp": {"added": [], "removed": [], "newly_archived": []},
+                "news": {"added": []},
+                "events": {"added": []},
+            },
+            "cc_portal": {"news": {"added": []}, "pps": {"added": []}, "products": {"added": []}},
+            "cctl_labs": {},
+            "csfc": {
+                "feeds": {},
+                "pages": {"apl": {"added": [], "removed": [], "updated": updated_items or []}},
+                "selection_links": {},
+            },
+            "cc_crypto": {"pages": {}, "doc_headers": {}},
+            "nist": {"pages": {}, "doc_headers": {}, "feeds": {}},
+            "nato": {"pages": {}, "cisco_added": [], "cisco_removed": []},
+            "eucc": {"pages": {}, "cisco_added": [], "cisco_removed": []},
+            "alerts": [],
+        }
+
+    def test_updated_bucket_merged_across_days(self):
+        item_a = {"href": "https://x/1", "text": "Component A revised"}
+        item_b = {"href": "https://x/2", "text": "Component B revised"}
+        d1 = self._make_diff_with_apl_updated([item_a])
+        d2 = self._make_diff_with_apl_updated([item_b])
+
+        result = differ.merge_weekly_diffs([d1, d2])
+
+        assert len(result["csfc"]["pages"]["apl"]["updated"]) == 2
+
+    def test_missing_updated_key_in_daily_diff_does_not_break_merge(self):
+        """Backward compatibility: daily diffs produced before this feature have
+        no 'updated' key. merge_weekly_diffs() must not raise, and must not
+        fabricate an 'updated' key that was never present."""
+        d1 = self._make_diff_with_apl_updated()
+        d1["csfc"]["pages"]["apl"] = {"added": [{"href": "https://x/1", "text": "New"}], "removed": []}
+        d2 = self._make_diff_with_apl_updated()
+        d2["csfc"]["pages"] = {}
+
+        result = differ.merge_weekly_diffs([d1, d2])  # should not raise
+
+        assert "updated" not in result["csfc"]["pages"]["apl"]

--- a/tests/test_emailer_csfc_updated.py
+++ b/tests/test_emailer_csfc_updated.py
@@ -1,0 +1,60 @@
+"""Regression tests for the CSfC Components List "updated" notification path.
+
+CC Pulse previously diffed the CSfC Components List purely by text prefix, so
+a cosmetic listing edit (a cert-date tweak, a description reformat) with the
+underlying product/VID unchanged showed up as a confusing removed+added pair
+in the weekly digest. This "updated" category reports those cosmetic edits
+distinctly instead. These tests pin the emailer-facing behaviour: the
+plain-language blurb and the rendered email row for CSfC Components List
+"updated" items.
+"""
+import emailer
+
+def test_describe_change_csfc_components_list_updated():
+    result = emailer._describe_change("updated", "CSfC Components List")
+    assert "revised" in result.lower() or "updated" in result.lower()
+    assert "not a new product" in result.lower()
+
+def test_describe_change_does_not_use_apl_abbreviation():
+    """The CSfC Components List used to be labelled "APL" in user-facing
+    text; that abbreviation has been dropped in favour of the NSA's own
+    name for the list."""
+    result = emailer._describe_change("updated", "CSfC Components List")
+    assert "(APL)" not in result
+
+def test_build_email_html_renders_csfc_updated_row():
+    weekly_diff = {
+        "csfc": {
+            "pages": {
+                "apl": {
+                    "added": [],
+                    "removed": [],
+                    "updated": [{
+                        "text": "Cisco Secure Firewall listing revised",
+                        "href": "https://example.test/component",
+                    }],
+                },
+            },
+        },
+    }
+    html = emailer.build_email_html(weekly_diff)
+    assert "Cisco Secure Firewall listing revised" in html
+    assert "https://example.test/component" in html
+    assert "Components List-UPD" in html
+
+def test_build_email_html_csfc_section_heading_uses_components_list():
+    """The section heading previously read "CSfC — Capability Packages & APL"."""
+    weekly_diff = {
+        "csfc": {
+            "pages": {
+                "apl": {
+                    "added": [{"text": "New component", "href": "https://example.test/new"}],
+                    "removed": [],
+                },
+            },
+        },
+    }
+    html = emailer.build_email_html(weekly_diff)
+    assert "Capability Packages" in html
+    assert "& APL" not in html
+    assert "Components List" in html


### PR DESCRIPTION
CSfC APL entries were diffed by 120-char text prefix (_diff_pages), so any edit to an existing listing's wording (cert-date tweak, description reformat) with the same underlying product/VID showed up as a spurious removed+added pair instead of a single update.

- differ.py: add _diff_csfc_apl() which keys APL records by their stable href (falling back to text prefix), and reports same-key text changes as "updated" instead of remove+add. diff_csfc() now routes the "apl" page through this helper while all other CSfC pages keep using the generic _diff_pages(). flag_alerts() and merge_weekly_diffs() gain matching "updated" handling. - dashboard.py: _section_daily_counts(), render_dashboard()'s csfc_total, _build_history(), and the CSfC template section all now include "updated" APL/announcement items alongside added/removed. - emailer.py: new plain-language description for ("updated", "CSfC APL") and a matching row in the CSfC email section.

                  All changes read the new "updated" key defensively via .get(...,
                  []), so existing diffs/tests without that key are unaffected.