### PR TITLE
Repair source parsing, identity, and health coverage

### DIFF
--- a/.github/workflows/send_filtered_stored_alert.yml
+++ b/.github/workflows/send_filtered_stored_alert.yml
@@ -8,13 +8,22 @@ on:
         required: true
         type: string
       source:
-        description: "Exact alert source, or NIAP News ID"
+        description: "Exact alert source, NIAP News ID, or Snapshot Record"
         required: true
         type: string
       title:
-        description: "Exact alert title, or numeric NIAP announcement ID"
+        description: "Exact title, NIAP ID, or snapshot-record selector"
         required: true
         type: string
+      record_kind:
+        description: "Used only when source is Snapshot Record"
+        required: true
+        default: "cc-portal-pp"
+        type: choice
+        options:
+          - cc-portal-pp
+          - cc-portal-product
+          - csfc-component
       dry_run:
         description: "Validate the match without sending notifications"
         required: true
@@ -49,7 +58,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Select and send alert
-        if: ${{ inputs.source != 'NIAP News ID' }}
+        if: ${{ inputs.source != 'NIAP News ID' && inputs.source != 'Snapshot Record' }}
         env:
           ALERT_DATE: ${{ inputs.date }}
           ALERT_SOURCE: ${{ inputs.source }}
@@ -118,4 +127,33 @@ jobs:
           --snapshot-dir snapshot-store
           --date "$BACKFILL_DATE"
           --news-id "$BACKFILL_NEWS_ID"
+          --send
+
+      - name: Validate stored source record
+        if: ${{ inputs.source == 'Snapshot Record' && inputs.dry_run }}
+        env:
+          BACKFILL_DATE: ${{ inputs.date }}
+          BACKFILL_KIND: ${{ inputs.record_kind }}
+          BACKFILL_SELECTOR: ${{ inputs.title }}
+        run: >-
+          python scripts/webex/backfill_source_record.py
+          --snapshot-dir snapshot-store
+          --date "$BACKFILL_DATE"
+          --kind "$BACKFILL_KIND"
+          --selector "$BACKFILL_SELECTOR"
+
+      - name: Send stored source record
+        if: ${{ inputs.source == 'Snapshot Record' && !inputs.dry_run }}
+        env:
+          BACKFILL_DATE: ${{ inputs.date }}
+          BACKFILL_KIND: ${{ inputs.record_kind }}
+          BACKFILL_SELECTOR: ${{ inputs.title }}
+          CC_WEBEX_BOT_TOKEN: ${{ secrets.CC_WEBEX_BOT_TOKEN }}
+          CC_WEBEX_ROOM_ID: ${{ secrets.CC_WEBEX_ROOM_ID }}
+        run: >-
+          python scripts/webex/backfill_source_record.py
+          --snapshot-dir snapshot-store
+          --date "$BACKFILL_DATE"
+          --kind "$BACKFILL_KIND"
+          --selector "$BACKFILL_SELECTOR"
           --send

--- a/collector.py
+++ b/collector.py
@@ -14,6 +14,7 @@ Features:
 
 import hashlib
 import copy
+import html
 import json
 import logging
 import re
@@ -109,11 +110,48 @@ def get_html(url, timeout=30):
     return result
 
 def get_rss(url):
-    def _parse(u, **kw):
-        feed = feedparser.parse(u)
-        if feed.get("bozo") and not feed.entries:
+    return _get_rss(url)[0]
+
+
+def _get_rss(url: str) -> tuple[list[dict], dict]:
+    """Fetch and parse an HTTPS RSS/Atom feed with explicit health metadata.
+
+    ``feedparser.parse(url)`` uses its own network client, bypassing the
+    browser-like session headers used by the rest of CC Pulse. CISA currently
+    rejects that path with malformed block-page XML. Fetching bounded bytes
+    through ``SESSION`` first keeps networking behavior consistent and makes
+    feed failures observable instead of silently returning an empty list.
+    """
+    parsed = urlsplit(url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not host:
+        return [], {
+            "success": False,
+            "complete": False,
+            "observed": 0,
+            "detail": "feed URL must use HTTPS",
+        }
+    allowed_hosts = {host}
+    if host.startswith("www."):
+        allowed_hosts.add(host[4:])
+    else:
+        allowed_hosts.add(f"www.{host}")
+    max_bytes = getattr(config, "RSS_FEED_MAX_BYTES", 2 * 1024 * 1024)
+    if not isinstance(max_bytes, int) or max_bytes <= 0:
+        max_bytes = 2 * 1024 * 1024
+
+    def _parse(target: str) -> tuple[list[dict], dict]:
+        fetched = _fetch_fixed_source(
+            target,
+            allowed_hosts=allowed_hosts,
+            max_bytes=max_bytes,
+            accept="application/atom+xml,application/rss+xml,application/xml,text/xml;q=0.9,*/*;q=0.1",
+        )
+        feed = feedparser.parse(fetched["content"])
+        bozo = bool(feed.get("bozo"))
+        if bozo and not feed.entries:
             raise ValueError(f"feedparser bozo error: {feed.get('bozo_exception')}")
-        return [
+        items = [
             {
                 "title":     e.get("title", ""),
                 "link":      e.get("link", ""),
@@ -123,8 +161,27 @@ def get_rss(url):
             }
             for e in feed.entries
         ]
+        return items, {
+            "success": True,
+            "complete": not bozo,
+            "observed": len(items),
+            "detail": (
+                f"feed parsed with warning: {feed.get('bozo_exception')}"
+                if bozo else ""
+            ),
+            "url": fetched["url"],
+            "sha256": fetched["sha256"],
+        }
+
     result = _fetch_with_retry(_parse, url)
-    return result if result is not None else []
+    if result is None:
+        return [], {
+            "success": False,
+            "complete": False,
+            "observed": 0,
+            "detail": "feed fetch or parse failed after retries",
+        }
+    return result
 
 
 def _fetch_fixed_source(
@@ -713,35 +770,114 @@ def parsecc_news(soup):
             items.append({"text": text, "link": href})
     return items
 
+
+def _clean_portal_value(value) -> str:
+    """Normalize one display value from CC Portal's embedded JSON."""
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", html.unescape(str(value))).strip()
+
+
+def _extract_cc_portal_json(soup, variable_name: str) -> list[dict]:
+    """Decode one allow-listed JavaScript JSON array from a portal page.
+
+    The portal renders PP and product tables client-side from ``ppList`` and
+    ``productList``. The values are JSON, so use the standard decoder at the
+    exact variable assignment; never execute page JavaScript.
+    """
+    allowed = {"ppList", "productList"}
+    if variable_name not in allowed or not soup:
+        return []
+    max_chars = getattr(config, "CC_PORTAL_EMBEDDED_JSON_MAX_CHARS", 20 * 1024 * 1024)
+    if not isinstance(max_chars, int) or max_chars <= 0:
+        max_chars = 20 * 1024 * 1024
+    assignment = re.compile(
+        rf"\b(?:var|let|const)\s+{re.escape(variable_name)}\s*=\s*"
+    )
+    decoder = json.JSONDecoder()
+    for script in soup.find_all("script"):
+        source = script.string or script.get_text() or ""
+        if not source or len(source) > max_chars:
+            continue
+        match = assignment.search(source)
+        if not match:
+            continue
+        try:
+            value, _ = decoder.raw_decode(source, match.end())
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            log.warning("[CC Portal] Could not decode %s: %s", variable_name, exc)
+            return []
+        if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+            log.warning("[CC Portal] %s was not a list of records", variable_name)
+            return []
+        return value
+    log.warning("[CC Portal] Embedded %s assignment was not found", variable_name)
+    return []
+
+
+def _cc_portal_file_url(folder: str, filename) -> str:
+    filename = _clean_portal_value(filename)
+    if not filename:
+        return ""
+    encoded = quote(filename, safe="/%")
+    return f"{config.CC_PORTAL_BASE}/nfs/ccpfiles/files/{folder}/{encoded}"
+
+
 def parsecc_pps(soup):
     rows = []
-    if not soup:
-        return rows
-    table = soup.find("table")
-    if not table:
-        return rows
-    headers = [th.get_text(strip=True) for th in table.find_all("th")]
-    for tr in table.find_all("tr")[1:]:
-        cells = [td.get_text(strip=True) for td in tr.find_all("td")]
-        if cells:
-            row = dict(zip(headers, cells))
-            link = tr.find("a")
-            row["_link"] = link["href"] if link and link.get("href") else ""
-            rows.append(row)
+    for source in _extract_cc_portal_json(soup, "ppList"):
+        portal_id = _clean_portal_value(source.get("ID"))
+        internal_id = _clean_portal_value(source.get("PPID"))
+        pp_id = _clean_portal_value(source.get("Abbr")) or portal_id or internal_id
+        title = _clean_portal_value(source.get("Name"))
+        if not pp_id or not title:
+            continue
+        rows.append({
+            "id": pp_id,
+            "pp_id": pp_id,
+            "portal_id": portal_id,
+            "internal_id": internal_id,
+            "title": title,
+            "text": title,
+            "abbr": _clean_portal_value(source.get("Abbr")),
+            "version": _clean_portal_value(source.get("Version")),
+            "scheme": _clean_portal_value(source.get("Scheme")),
+            "eal": _clean_portal_value(source.get("eal_name") or source.get("EAL")),
+            "issue_date": _clean_portal_value(source.get("Issue_Date")),
+            "entry_date": _clean_portal_value(source.get("EntryDate")),
+            "archived": source.get("Archived"),
+            "link": _cc_portal_file_url("ppfiles", source.get("PDF_PP")),
+            "certificate_link": _cc_portal_file_url("ppfiles", source.get("PDF_Cert")),
+            "supporting_document_link": _cc_portal_file_url("ppfiles", source.get("PDF_SD")),
+        })
     return rows
 
 def parsecc_products(soup):
     rows = []
-    if not soup:
-        return rows
-    table = soup.find("table")
-    if not table:
-        return rows
-    headers = [th.get_text(strip=True) for th in table.find_all("th")]
-    for tr in table.find_all("tr")[1:]:
-        cells = [td.get_text(strip=True) for td in tr.find_all("td")]
-        if cells:
-            rows.append(dict(zip(headers, cells)))
+    for source in _extract_cc_portal_json(soup, "productList"):
+        product_id = _clean_portal_value(source.get("id"))
+        title = _clean_portal_value(source.get("name"))
+        if not product_id or not title:
+            continue
+        certificate_link = _cc_portal_file_url("epfiles", source.get("pdf_cert"))
+        security_target_link = _cc_portal_file_url("epfiles", source.get("pdf_st"))
+        rows.append({
+            "id": product_id,
+            "product_id": product_id,
+            "title": title,
+            "name": title,
+            "text": title,
+            "vendor": _clean_portal_value(source.get("vendor_name")),
+            "scheme": _clean_portal_value(source.get("scheme_name") or source.get("scheme")),
+            "category": _clean_portal_value(source.get("category_name")),
+            "eal": _clean_portal_value(source.get("eal_name") or source.get("eal")),
+            "certificate_date": _clean_portal_value(source.get("certified")),
+            "archive_date": _clean_portal_value(source.get("archived")),
+            "link": certificate_link or security_target_link,
+            "certificate_link": certificate_link,
+            "security_target_link": security_target_link,
+            "vendor_url": _clean_portal_value(source.get("www")),
+        })
     return rows
 
 def parsecc_communities(soup):
@@ -783,11 +919,17 @@ def collect_cc_portal():
 
 
 # ── CCTL Labs ─────────────────────────────────────────────────────────────────
-def scrapelab_items(url):
+def scrapelab_items(url, *, with_health: bool = False):
     """Generic scraper — extracts headlines/links from a lab page."""
     soup = get_html(url)
     if not soup:
-        return []
+        health = {
+            "success": False,
+            "complete": False,
+            "observed": 0,
+            "detail": "page fetch failed",
+        }
+        return ([], health) if with_health else []
     items = []
     for tag in soup.find_all(["h2", "h3", "h4", "article"]):
         a = tag.find("a") if tag.name != "a" else tag
@@ -801,7 +943,14 @@ def scrapelab_items(url):
                 "published": "",
                 "id":        href or a.get_text(strip=True),
             })
-    return items[:20]
+    items = items[:20]
+    health = {
+        "success": True,
+        "complete": True,
+        "observed": len(items),
+        "detail": "" if items else "page returned no recognizable items",
+    }
+    return (items, health) if with_health else items
 
 def collect_cctl_labs():
     """Collect CCTL lab blog/news items.
@@ -873,6 +1022,23 @@ def validate_snapshot(snapshot):
             f"(minimum expected: {config.SANITY_MIN_PPS}). "
             "Snapshot rejected — possible fetch failure."
         )
+
+    cc_portal = snapshot.get("cc_portal", {})
+    for label, key, minimum_name, default in (
+        ("news", "news", "SANITY_MIN_CC_PORTAL_NEWS", 50),
+        ("Protection Profiles", "pps", "SANITY_MIN_CC_PORTAL_PPS", 100),
+        ("certified products", "products", "SANITY_MIN_CC_PORTAL_PRODUCTS", 500),
+    ):
+        minimum = getattr(config, minimum_name, default)
+        if not isinstance(minimum, int):
+            minimum = default
+        observed = len(cc_portal.get(key, []))
+        if observed < minimum:
+            log.warning(
+                "CC Portal %s returned only %d items (minimum expected: %d). "
+                "Snapshot kept but source health will retain last-known-good.",
+                label, observed, minimum,
+            )
 
     # Warn-only checks — external sites that may legitimately be slow/blocked
     csfc_apl_count = len(snapshot.get("csfc", {}).get("pages", {}).get("apl", []))
@@ -1803,6 +1969,7 @@ def collect_csfc() -> dict:
         "selection_links": {},
         "documents": {},
         "feeds": {},
+        "_feed_health": {},
     }
 
     # Warm up the session on the NSA base domain to pick up any required
@@ -1850,12 +2017,19 @@ def collect_csfc() -> dict:
         name = feed["name"]
         log.debug("  [CSfC] Feed: %s...", name)
         if feed.get("rss"):
-            items = get_rss(feed["rss"])
+            items, health = _get_rss(feed["rss"])
         elif feed.get("scrape") and feed.get("url"):
-            items = scrapelab_items(feed["url"])
+            items, health = scrapelab_items(feed["url"], with_health=True)
         else:
             items = []
+            health = {
+                "success": False,
+                "complete": False,
+                "observed": 0,
+                "detail": "feed has no configured collector",
+            }
         data["feeds"][name] = items
+        data["_feed_health"][name] = health
         log.debug("    -> %d items", len(items))
 
     apl_count = len(data["pages"].get("apl", []))

--- a/config.py
+++ b/config.py
@@ -60,6 +60,9 @@ SANITY_MIN_PPS = 10
 SANITY_MIN_CSFC_APL = 5
 SANITY_MIN_CSFC_ANNOUNCEMENTS = 1
 SANITY_MIN_CC_CRYPTO_PUBS = 5
+SANITY_MIN_CC_PORTAL_NEWS = 50
+SANITY_MIN_CC_PORTAL_PPS = 100
+SANITY_MIN_CC_PORTAL_PRODUCTS = 500
 
 # -- Per-collection collapse guard ------------------------------------------
 # A domain can pass its representative sanity check (e.g. NIAP PCL is fine)
@@ -120,6 +123,8 @@ CC_PORTAL_PAGES = {
     "publications": "/cc/index.cfm",
 }
 CC_PORTAL_RSS = "https://www.commoncriteriaportal.org/rss/pps.xml"
+CC_PORTAL_EMBEDDED_JSON_MAX_CHARS = 20 * 1024 * 1024
+RSS_FEED_MAX_BYTES = 2 * 1024 * 1024
 
 # -- CCTL Lab Feeds ---------------------------------------------------------
 CCTL_LABS = [
@@ -222,9 +227,9 @@ CSFC_PAGES = {
 CSFC_PRODUCT_LIST_URL = "https://www.nsa.gov/Resources/Commercial-Solutions-for-Classified-Program/Components-List/"  # CSfC APL: confirmed correct (Components List = approved CC-evaluated products for CSfC)
 
 CSFC_FEEDS = [
-    {"name": "NSA Cybersecurity Advisories", "rss": "https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=1282&max=20", "scrape": False},
-    {"name": "CISA Alerts", "rss": "https://www.cisa.gov/cybersecurity-advisories/all.xml", "scrape": False},
-    {"name": "DISA STIGs & APL News", "rss": None, "url": "https://public.cyber.mil/stigs/", "scrape": True},
+    {"name": "NSA Cybersecurity Advisories", "rss": "https://www.nsa.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=1282&max=20", "scrape": False, "minimum": 1},
+    {"name": "CISA Alerts", "rss": "https://www.cisa.gov/cybersecurity-advisories/all.xml", "scrape": False, "minimum": 1},
+    {"name": "DISA STIGs & APL News", "rss": None, "url": "https://public.cyber.mil/stigs/", "scrape": True, "minimum": 1},
 ]
 
 CSFC_APL_COMPONENT_KEYWORDS = {
@@ -310,6 +315,8 @@ EUCC_TIER1_KEYWORDS = [
 
 # Sanity minimum: EUCC certificates page should have some entries
 SANITY_MIN_EUCC_CERTS = 2
+EUCC_CONTINUITY_MIN_BASELINE = 10
+EUCC_MIN_IDENTITY_OVERLAP = 0.70
 
 # =============================================================
 # ND-iTC (Network Device iTC) Monitoring — nd-itc.github.io

--- a/dashboard.py
+++ b/dashboard.py
@@ -1126,8 +1126,8 @@ DASHBOARD_TEMPLATE = """
     <div class="sub-hdr sub-new">New Certified Products ({{ diff.cc_portal.products.added | length }})</div>
     {% for prod in diff.cc_portal.products.added %}
     <div class="item-row" data-source="cc-portal" data-kind="new">
-      <span class="item-link">{{ prod }}</span>
-      <span class="item-meta"></span>
+      <a class="item-link" href="{{ (prod.link or prod.certificate_link or 'https://www.commoncriteriaportal.org/products/') | safe_url }}" target="_blank">{{ prod.title or prod.name or prod.text or prod }}</a>
+      <span class="item-meta">{{ prod.vendor or '' }}{% if prod.certificate_date %} · {{ prod.certificate_date }}{% endif %}</span>
     </div>
     {% endfor %}
     {% endif %}

--- a/differ.py
+++ b/differ.py
@@ -12,6 +12,7 @@ import json
 import logging
 import re
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import config
 
@@ -801,15 +802,32 @@ def diff_cc_news(old_items: Records, new_items: Records) -> dict[str, Any]:
 
 def diff_cc_pps(old_pps: Records, new_pps: Records) -> dict[str, Any]:
     def key(row: dict) -> str:
-        vals = list(row.values())
-        return vals[0] if vals else ""
+        return str(
+            row.get("id")
+            or row.get("pp_id")
+            or row.get("PPID")
+            or row.get("ID")
+            or row.get("link")
+            or row.get("title")
+            or row.get("text")
+            or ""
+        ).strip()
     old_keys = {key(r) for r in old_pps}
     return {"added": [r for r in new_pps if key(r) not in old_keys]}
 
 def diff_cc_products(old_products: Records, new_products: Records) -> dict[str, Any]:
     def key(row: dict) -> str:
-        vals = list(row.values())
-        return " ".join(vals[:2]) if len(vals) >= 2 else (vals[0] if vals else "")
+        product_id = row.get("id") or row.get("product_id") or row.get("ID")
+        if product_id not in (None, ""):
+            return f"id:{str(product_id).strip()}"
+        title = re.sub(
+            r"\s+", " ", str(row.get("title") or row.get("name") or "")
+        ).strip().casefold()
+        cert_date = str(
+            row.get("certificate_date") or row.get("certified") or ""
+        ).strip().casefold()
+        link = str(row.get("link") or row.get("certificate_link") or "").strip()
+        return f"metadata:{title}|{cert_date}" if title else f"url:{link}"
     old_keys = {key(r) for r in old_products}
     return {"added": [r for r in new_products if key(r) not in old_keys]}
 
@@ -962,24 +980,62 @@ def _diff_named_documents(old_docs: dict, new_docs: dict) -> dict:
     return {"added": added, "removed": removed, "updated": updated}
 
 
-# -- CSfC Components List diff helper (keyed by stable link, not text prefix) ------------
+# -- CSfC Components List diff helper -----------------------------------------
+def _normalize_csfc_component_type(value) -> str:
+    return re.sub(r"\s+", " ", str(value or "").replace("\xa0", " ")).strip().casefold()
+
+
+def _csfc_apl_key(item: dict) -> str:
+    """Stable CSfC APL identity: NIAP product plus component role.
+
+    A single NIAP validation can appear under multiple CSfC component types.
+    URL-only identity collapsed those roles into one row and hid additions.
+    NIAP product IDs also survive URL capitalization and international-product
+    path changes better than the raw URL.
+    """
+    component_type = _normalize_csfc_component_type(item.get("type"))
+    href = str(item.get("href") or "").strip()
+    if href:
+        parsed = urlsplit(href)
+        product_match = re.search(
+            r"/products/(?:international-product/)?([0-9]+(?:\.[0-9]+)*)(?:/|$)",
+            parsed.path,
+            flags=re.IGNORECASE,
+        )
+        if product_match and (parsed.hostname or "").casefold().endswith("niap-ccevs.org"):
+            identity = f"niap:{product_match.group(1)}"
+        else:
+            normalized_url = urlunsplit((
+                parsed.scheme.casefold(),
+                parsed.netloc.casefold(),
+                parsed.path.rstrip("/") or "/",
+                "",
+                "",
+            ))
+            identity = f"url:{normalized_url}"
+    else:
+        text = re.sub(r"\s+", " ", str(item.get("text") or "")).strip().casefold()
+        identity = f"text:{text[:120]}"
+    return f"{identity}|type:{component_type}"
+
+
 def _diff_csfc_apl(old_items: list, new_items: list) -> dict:
-    """Diff CSfC Components List entries, keyed by their NIAP link.
+    """Diff CSfC Components List entries by product and component role.
 
     _diff_pages() keys purely on the first 120 chars of display text, so an
     edit to an existing listing's wording (a cert-date tweak, a description
     reformat) with the underlying product/VID unchanged shows up as a
     spurious removed+added pair. APL records carry a stable href to the
     underlying NIAP product page (collector._parse_csfc_apl_structured), so
-    key on that instead (falling back to the text prefix for any record
-    without one) and report same-key text changes as "updated".
+    key on that plus the component type (falling back to the text prefix for
+    any record without a link) and report same-key text changes as "updated".
     """
     old_by_key = {
-        _record_key(item, url_field="href", text_field="text"): item
+        _csfc_apl_key(item): item
         for item in old_items
     }
     new_by_key = {
-        _record_key(item, url_field="href", text_field="text"): item
+        _csfc_apl_key(item): item
         for item in new_items
     }
     old_keys = set(old_by_key)

--- a/emailer.py
+++ b/emailer.py
@@ -255,7 +255,7 @@ def _format_alert_lines(alerts: list[dict], max_items: int = 15) -> list[str]:
 # Webex notification
 # ---------------------------------------------------------------------------
 
-def send_webex_alert(alerts: list[dict]) -> None:
+def send_webex_alert(alerts: list[dict]) -> bool:
     """POST an actionable Webex message for high-priority keyword alerts.
 
     Message structure:
@@ -269,9 +269,9 @@ def send_webex_alert(alerts: list[dict]) -> None:
     room_id = config.WEBEX_ROOM_ID
     if not token or not room_id:
         log.debug("[Webex] Bot token or Room ID not configured — skipping.")
-        return
+        return False
     if not alerts:
-        return
+        return False
 
     tier_counts = {1: 0, 2: 0, 3: 0}
     for a in alerts:
@@ -309,8 +309,10 @@ def send_webex_alert(alerts: list[dict]) -> None:
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             log.info("[Webex] Alert sent (HTTP %d).", resp.status)
+            return True
     except urllib.error.URLError as exc:
         log.warning("[Webex] Failed to send message: %s", exc)
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -1510,6 +1512,15 @@ def send_source_health_email(source_health: dict[str, dict]) -> None:
     _send_email(subject, html)
 
 
+def _degraded_source_health(source_health: dict) -> dict:
+    """Return domains whose core collection or auxiliary coverage degraded."""
+    return {
+        source: health for source, health in source_health.items()
+        if health.get("status") in ("stale", "failed")
+        or health.get("auxiliary_status") == "degraded"
+    }
+
+
 def send_daily_status_email(diff: dict, run_date: str = "") -> None:
     """Send a brief daily status email summarising what CC Pulse found today.
 
@@ -1543,10 +1554,7 @@ def send_daily_status_email(diff: dict, run_date: str = "") -> None:
     niap_pp_changes = len(diff.get("niap", {}).get("pps", {}).get("added", [])) + \
                       len(diff.get("niap", {}).get("pps", {}).get("sunset_changes", []))
     total_changes = len(alerts) + len(new_tds) + len(new_certs) + len(nato_adds) + len(eucc_adds) + cc_crypto_new + niap_pp_changes
-    unhealthy_sources = {
-        source: health for source, health in diff.get("source_health", {}).items()
-        if health.get("status") in ("stale", "failed")
-    }
+    unhealthy_sources = _degraded_source_health(diff.get("source_health", {}))
 
     if unhealthy_sources:
         status_icon = "⚠️"
@@ -1556,8 +1564,9 @@ def send_daily_status_email(diff: dict, run_date: str = "") -> None:
         for source, health in sorted(unhealthy_sources.items()):
             label = health.get("label") or source.replace("_", " ").title()
             fallback = " (last-known-good data retained)" if health.get("using_last_known_good") else ""
+            displayed_status = health.get("auxiliary_status") or health.get("status", "failed")
             health_lines.append(
-                f"{label}: {health.get('status', 'failed')} — {health.get('detail', '')}{fallback}"
+                f"{label}: {displayed_status} — {health.get('detail', '')}{fallback}"
             )
         body_detail = (
             "<p style='margin:0 0 12px;color:#94a3b8;font-size:14px;'>"

--- a/main.py
+++ b/main.py
@@ -228,6 +228,93 @@ def _apply_niap_subcollection_health(
     return result
 
 
+def _apply_csfc_feed_health(
+    new_snapshot: dict,
+    prior_snapshot: dict,
+) -> dict[str, dict]:
+    """Validate each configured CSfC auxiliary feed independently.
+
+    A broken CISA or DISA feed must be visible without freezing a healthy APL
+    collection. Failed feeds selectively retain their own last-known-good
+    records and accumulate independent failure counters for escalation.
+    """
+    new_csfc = new_snapshot.setdefault("csfc", {})
+    metadata = new_csfc.get("_feed_health")
+    if not isinstance(metadata, dict):
+        return {}
+    new_feeds = new_csfc.setdefault("feeds", {})
+    prior_csfc = prior_snapshot.get("csfc", {})
+    prior_feeds = prior_csfc.get("feeds", {})
+    prior_subhealth = (
+        prior_snapshot.get("source_health", {})
+        .get("csfc", {})
+        .get("subcollections", {})
+    )
+    result: dict[str, dict] = {}
+
+    configured_feeds = getattr(config, "CSFC_FEEDS", [])
+    if not isinstance(configured_feeds, (list, tuple)):
+        return {}
+    for feed in configured_feeds:
+        if not isinstance(feed, dict) or not feed.get("name"):
+            continue
+        name = str(feed["name"])
+        minimum = feed.get("minimum", 1)
+        if not isinstance(minimum, int) or minimum < 0:
+            minimum = 1
+        current_items = new_feeds.get(name, [])
+        prior_items = prior_feeds.get(name, [])
+        observed = len(current_items) if isinstance(current_items, list) else 0
+        prior_count = len(prior_items) if isinstance(prior_items, list) else 0
+        meta = metadata.get(name, {}) if isinstance(metadata.get(name), dict) else {}
+        successful = meta.get("success") is True and meta.get("complete", True) is True
+        current_ok = successful and observed >= minimum
+
+        if current_ok:
+            result[name] = {
+                "label": name,
+                "status": "healthy",
+                "observed": observed,
+                "consecutive_failures": 0,
+                "using_last_known_good": False,
+            }
+            continue
+
+        previous = prior_subhealth.get(name, {})
+        previous_failures = (
+            previous.get("consecutive_failures", 0)
+            if previous.get("status") in ("stale", "failed") else 0
+        )
+        has_last_known_good = (
+            previous.get("status") == "healthy"
+            or previous.get("using_last_known_good") is True
+            or prior_count >= max(1, minimum)
+        )
+        if has_last_known_good:
+            new_feeds[name] = copy.deepcopy(prior_items)
+        reasons = []
+        if not successful:
+            reasons.append(meta.get("detail") or "request failed or was incomplete")
+        if observed < minimum:
+            reasons.append(f"returned {observed}; minimum expected {minimum}")
+        result[name] = {
+            "label": name,
+            "status": "stale" if has_last_known_good else "failed",
+            "observed": observed,
+            "consecutive_failures": previous_failures + 1,
+            "using_last_known_good": has_last_known_good,
+            "detail": "; ".join(reasons),
+        }
+        log.warning(
+            "[Health] CSfC feed %s is %s (failure #%d): %s",
+            name,
+            result[name]["status"],
+            result[name]["consecutive_failures"],
+            result[name]["detail"],
+        )
+    return result
+
+
 def _source_health_checks(snapshot: dict) -> dict[str, list[dict]]:
     """Return the minimum viable collection checks for every source domain.
 
@@ -263,9 +350,12 @@ def _source_health_checks(snapshot: dict) -> dict[str, list[dict]]:
              "required_for_diff_baseline": False},
         ],
         "cc_portal": [
-            {"name": "portal records", "observed": sum(
-                len(cc_portal.get(key, [])) for key in ("news", "pps", "products")
-            ), "minimum": 1},
+            {"name": "news", "observed": len(cc_portal.get("news", [])),
+             "minimum": _config_minimum("SANITY_MIN_CC_PORTAL_NEWS", 50)},
+            {"name": "Protection Profiles", "observed": len(cc_portal.get("pps", [])),
+             "minimum": _config_minimum("SANITY_MIN_CC_PORTAL_PPS", 100)},
+            {"name": "certified products", "observed": len(cc_portal.get("products", [])),
+             "minimum": _config_minimum("SANITY_MIN_CC_PORTAL_PRODUCTS", 500)},
         ],
         "cctl_labs": [
             {"name": "lab feed items", "observed": sum(
@@ -456,6 +546,99 @@ def _apply_collection_collapse_guard(
         )
 
 
+def _eucc_record_metadata_key(record: dict) -> str:
+    name = re.sub(r"\s+", " ", str(record.get("name") or "")).strip().casefold()
+    cert_date = re.sub(
+        r"\s+", " ", str(record.get("cert_date") or "")
+    ).strip().casefold()
+    return f"{name}|{cert_date}" if name and cert_date else ""
+
+
+def _eucc_identity_overlap(old_records: list, new_records: list) -> int:
+    """Count one-to-one EUCC matches by URL or product/date metadata."""
+    unmatched_new = set(range(len(new_records)))
+    overlap = 0
+    for old in old_records:
+        if not isinstance(old, dict):
+            continue
+        old_url = str(old.get("href") or "").strip()
+        old_metadata = _eucc_record_metadata_key(old)
+        for index in tuple(unmatched_new):
+            new = new_records[index]
+            if not isinstance(new, dict):
+                continue
+            same_url = bool(old_url and old_url == str(new.get("href") or "").strip())
+            same_metadata = bool(
+                old_metadata and old_metadata == _eucc_record_metadata_key(new)
+            )
+            if same_url or same_metadata:
+                unmatched_new.remove(index)
+                overlap += 1
+                break
+    return overlap
+
+
+def _apply_eucc_continuity_guard(
+    new_snapshot: dict,
+    prior_snapshot: dict,
+    source_health: dict[str, dict],
+) -> None:
+    """Reject same-count EUCC re-key/churn that count checks cannot see."""
+    health = source_health.get("eucc", {})
+    if health.get("status") != "healthy":
+        return
+    old_eucc = prior_snapshot.get("eucc", {})
+    new_eucc = new_snapshot.get("eucc", {})
+    old_records = old_eucc.get("pages", {}).get("certificates", [])
+    new_records = new_eucc.get("pages", {}).get("certificates", [])
+    if not isinstance(old_records, list) or not isinstance(new_records, list):
+        return
+    minimum = _config_minimum("EUCC_CONTINUITY_MIN_BASELINE", 10)
+    denominator = min(len(old_records), len(new_records))
+    if len(old_records) < minimum or denominator == 0:
+        return
+    configured_threshold = getattr(config, "EUCC_MIN_IDENTITY_OVERLAP", 0.70)
+    threshold = (
+        float(configured_threshold)
+        if isinstance(configured_threshold, (int, float))
+        and not isinstance(configured_threshold, bool)
+        and 0 <= configured_threshold <= 1
+        else 0.70
+    )
+    overlap = _eucc_identity_overlap(old_records, new_records)
+    ratio = overlap / denominator
+    health["continuity"] = {
+        "overlap": overlap,
+        "compared": denominator,
+        "ratio": round(ratio, 4),
+        "minimum_ratio": threshold,
+    }
+    if ratio >= threshold:
+        return
+
+    # Retain only the suspect certificate subcollection. Current requirements
+    # and scheme-news data remain available for normal diffing.
+    new_eucc.setdefault("pages", {})["certificates"] = copy.deepcopy(old_records)
+    if "cisco_certs" in old_eucc:
+        new_eucc["cisco_certs"] = copy.deepcopy(old_eucc.get("cisco_certs", []))
+    previous = prior_snapshot.get("source_health", {}).get("eucc", {})
+    previous_failures = (
+        previous.get("consecutive_failures", 0)
+        if previous.get("status") in ("stale", "failed") else 0
+    )
+    detail = (
+        f"certificate identity overlap {overlap}/{denominator} "
+        f"({ratio:.0%}) below {threshold:.0%}; retained last-known-good certificates"
+    )
+    health.update({
+        "status": "stale",
+        "consecutive_failures": previous_failures + 1,
+        "using_last_known_good": True,
+        "detail": detail,
+    })
+    log.warning("[Health] EUCC degraded to stale: %s", detail)
+
+
 def _apply_source_health(
     new_snapshot: dict,
     prior_snapshot: dict | None = None,
@@ -471,6 +654,9 @@ def _apply_source_health(
     collection_errors = collection_errors or set()
     prior_snapshot = prior_snapshot or {}
     niap_subcollections = _apply_niap_subcollection_health(
+        new_snapshot, prior_snapshot
+    )
+    csfc_subcollections = _apply_csfc_feed_health(
         new_snapshot, prior_snapshot
     )
     current_checks = _source_health_checks(new_snapshot)
@@ -595,7 +781,24 @@ def _apply_source_health(
             source_health[domain]["detail"],
         )
 
+    if csfc_subcollections:
+        csfc_health = source_health.get("csfc", {})
+        csfc_health["subcollections"] = csfc_subcollections
+        degraded_feeds = [
+            health["label"] for health in csfc_subcollections.values()
+            if health.get("status") != "healthy"
+        ]
+        if degraded_feeds:
+            csfc_health["auxiliary_status"] = "degraded"
+            auxiliary_detail = "auxiliary feed failures: " + ", ".join(degraded_feeds)
+            existing_detail = csfc_health.get("detail")
+            csfc_health["detail"] = (
+                f"{existing_detail}; {auxiliary_detail}"
+                if existing_detail else auxiliary_detail
+            )
+
     _apply_collection_collapse_guard(new_snapshot, prior_snapshot, source_health)
+    _apply_eucc_continuity_guard(new_snapshot, prior_snapshot, source_health)
     new_snapshot["source_health"] = source_health
     return new_snapshot
 
@@ -645,6 +848,75 @@ def _diff_baseline_with_recoveries(old_snapshot: dict, new_snapshot: dict) -> di
             "[Health] %s produced its first healthy collection; baselining without alerts.",
             domain,
         )
+
+    # CC Portal moved from empty server-rendered tables to embedded JSON
+    # parsing. Baseline only the newly populated subcollections so hundreds of
+    # historical PPs/products do not appear as fresh certifications, while
+    # unrelated portal news changes still diff against the prior snapshot.
+    old_portal = old_snapshot.get("cc_portal", {})
+    new_portal = new_snapshot.get("cc_portal", {})
+    for key, minimum_name, default in (
+        ("pps", "SANITY_MIN_CC_PORTAL_PPS", 100),
+        ("products", "SANITY_MIN_CC_PORTAL_PRODUCTS", 500),
+    ):
+        old_items = old_portal.get(key, [])
+        new_items = new_portal.get(key, [])
+        minimum = _config_minimum(minimum_name, default)
+        if (
+            isinstance(old_items, list)
+            and isinstance(new_items, list)
+            and len(old_items) < minimum <= len(new_items)
+        ):
+            baseline.setdefault("cc_portal", {})[key] = copy.deepcopy(new_items)
+            log.info(
+                "[Health] CC Portal %s parser produced its first complete "
+                "collection; baselining without alerts.",
+                key,
+            )
+
+    # Likewise, establish each newly repaired CSfC auxiliary feed once. This
+    # prevents the first successful CISA fetch after a collector-client fix
+    # from looking like 30 newly published advisories. A feed with retained
+    # last-known-good data is not baselined, so outage-period changes survive.
+    old_csfc = old_snapshot.get("csfc", {})
+    new_csfc = new_snapshot.get("csfc", {})
+    old_csfc_health = (
+        old_snapshot.get("source_health", {}).get("csfc", {}).get("subcollections", {})
+    )
+    new_csfc_health = (
+        new_snapshot.get("source_health", {}).get("csfc", {}).get("subcollections", {})
+    )
+    configured_feeds = getattr(config, "CSFC_FEEDS", [])
+    if isinstance(configured_feeds, (list, tuple)):
+        for feed in configured_feeds:
+            if not isinstance(feed, dict) or not feed.get("name"):
+                continue
+            name = str(feed["name"])
+            minimum = feed.get("minimum", 1)
+            if not isinstance(minimum, int) or minimum < 0:
+                minimum = 1
+            old_items = old_csfc.get("feeds", {}).get(name, [])
+            old_feed_health = old_csfc_health.get(name, {})
+            new_feed_health = new_csfc_health.get(name, {})
+            no_trustworthy_baseline = (
+                not isinstance(old_items, list)
+                or len(old_items) < minimum
+            ) and not (
+                old_feed_health.get("status") == "healthy"
+                or old_feed_health.get("using_last_known_good") is True
+            )
+            if (
+                no_trustworthy_baseline
+                and new_feed_health.get("status") == "healthy"
+            ):
+                baseline.setdefault("csfc", {}).setdefault("feeds", {})[name] = (
+                    copy.deepcopy(new_csfc.get("feeds", {}).get(name, []))
+                )
+                log.info(
+                    "[Health] CSfC feed %s produced its first healthy collection; "
+                    "baselining without alerts.",
+                    name,
+                )
 
     # Baseline a newly introduced NIAP subcollection once. A recovery that
     # already has retained last-known-good data is intentionally *not*

--- a/scripts/webex/backfill_source_record.py
+++ b/scripts/webex/backfill_source_record.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Replay one CC Portal or CSfC record from a trusted daily snapshot.
+
+The command is dry-run by default. ``--send`` posts exactly one selected
+record through the normal CC Pulse keyword-alert Webex formatter.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import config  # noqa: E402
+import emailer  # noqa: E402
+
+
+MAX_SNAPSHOT_BYTES = 50 * 1024 * 1024
+RECORD_KINDS = ("cc-portal-pp", "cc-portal-product", "csfc-component")
+
+
+def snapshot_date(value: str) -> str:
+    """Require canonical YYYY-MM-DD input before constructing a path."""
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("date must use YYYY-MM-DD") from exc
+    if parsed.isoformat() != value:
+        raise argparse.ArgumentTypeError("date must use canonical YYYY-MM-DD")
+    return value
+
+
+def record_selector(value: str) -> str:
+    """Reject control characters and unbounded selectors from workflow input."""
+    if not value or len(value) > 200 or any(ord(char) < 32 for char in value):
+        raise argparse.ArgumentTypeError(
+            "record selector must contain 1-200 printable characters"
+        )
+    return value
+
+
+def _normalized_type(value) -> str:
+    return re.sub(r"\s+", " ", str(value or "").replace("\xa0", " ")).strip().casefold()
+
+
+def _csfc_selector(record: dict) -> str:
+    href = str(record.get("href") or "")
+    match = re.search(
+        r"/products/(?:international-product/)?([0-9]+(?:\.[0-9]+)*)(?:/|$)",
+        urlsplit(href).path,
+        flags=re.IGNORECASE,
+    )
+    product_id = match.group(1) if match else ""
+    component_type = _normalized_type(record.get("type"))
+    return f"{product_id}|{component_type}" if product_id and component_type else ""
+
+
+def _record_identity(kind: str, record: dict) -> str:
+    if kind == "cc-portal-pp":
+        return str(record.get("id") or record.get("pp_id") or "").strip()
+    if kind == "cc-portal-product":
+        return str(record.get("id") or record.get("product_id") or "").strip()
+    if kind == "csfc-component":
+        return _csfc_selector(record)
+    raise ValueError(f"unsupported record kind: {kind}")
+
+
+def _records_for_kind(payload: dict, kind: str) -> list:
+    if kind == "cc-portal-pp":
+        records = payload.get("cc_portal", {}).get("pps", [])
+    elif kind == "cc-portal-product":
+        records = payload.get("cc_portal", {}).get("products", [])
+    elif kind == "csfc-component":
+        records = payload.get("csfc", {}).get("pages", {}).get("apl", [])
+    else:
+        raise ValueError(f"unsupported record kind: {kind}")
+    if not isinstance(records, list):
+        raise ValueError(f"snapshot collection for {kind} is not a list")
+    return records
+
+
+def load_source_record(
+    snapshot_dir: str | Path,
+    selected_date: str,
+    kind: str,
+    selector: str,
+) -> dict:
+    """Load exactly one source record from a bounded daily snapshot."""
+    if kind not in RECORD_KINDS:
+        raise ValueError(f"unsupported record kind: {kind}")
+    root = Path(snapshot_dir).resolve()
+    snapshot_path = (root / f"{selected_date}.json").resolve()
+    if snapshot_path.parent != root:
+        raise ValueError("snapshot path escaped the configured snapshot directory")
+    if snapshot_path.stat().st_size > MAX_SNAPSHOT_BYTES:
+        raise ValueError("snapshot exceeds the replay size limit")
+
+    payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    records = _records_for_kind(payload, kind)
+    normalized_selector = (
+        selector.split("|", 1)[0] + "|" + _normalized_type(selector.split("|", 1)[1])
+        if kind == "csfc-component" and "|" in selector else selector
+    )
+    matches = [
+        record for record in records
+        if isinstance(record, dict)
+        and _record_identity(kind, record) == normalized_selector
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one {kind} record with selector {selector!r}; "
+            f"found {len(matches)}"
+        )
+    return copy.deepcopy(matches[0])
+
+
+def _https_url(value) -> str:
+    url = str(value or "").strip()
+    parsed = urlsplit(url)
+    return url if parsed.scheme == "https" and bool(parsed.hostname) else ""
+
+
+def build_alert(kind: str, record: dict) -> dict:
+    """Convert one trusted snapshot record to the normal alert contract."""
+    if kind == "cc-portal-pp":
+        return {
+            "source": "CC Portal Protection Profiles",
+            "kind": "new",
+            "title": str(record.get("title") or record.get("text") or record.get("id")),
+            "url": _https_url(record.get("link")),
+            "detail": " · ".join(filter(None, [
+                str(record.get("id") or ""),
+                str(record.get("scheme") or ""),
+                str(record.get("issue_date") or ""),
+            ])),
+            "matched_keywords": ["Protection Profile"],
+            "tab": "intl",
+        }
+    if kind == "cc-portal-product":
+        return {
+            "source": "CC Portal Certified Products",
+            "kind": "new_cert",
+            "title": str(record.get("title") or record.get("name") or record.get("id")),
+            "url": _https_url(record.get("link") or record.get("certificate_link")),
+            "detail": " · ".join(filter(None, [
+                str(record.get("vendor") or ""),
+                str(record.get("certificate_date") or ""),
+                str(record.get("scheme") or ""),
+            ])),
+            "matched_keywords": ["Common Criteria"],
+            "tab": "intl",
+        }
+    if kind == "csfc-component":
+        return {
+            "source": "CSfC Components List",
+            "kind": "new",
+            "title": str(record.get("text") or "CSfC component"),
+            "url": _https_url(record.get("href")),
+            "detail": str(record.get("type") or ""),
+            "matched_keywords": ["CSfC"],
+            "tab": "us",
+        }
+    raise ValueError(f"unsupported record kind: {kind}")
+
+
+def replay_source_record(
+    snapshot_dir: str | Path,
+    selected_date: str,
+    kind: str,
+    selector: str,
+    *,
+    send: bool = False,
+) -> dict:
+    """Validate one stored record and optionally send one Webex alert."""
+    record = load_source_record(snapshot_dir, selected_date, kind, selector)
+    alert = build_alert(kind, record)
+    print(
+        f"Selected {kind} record {selector!r} from {selected_date}: "
+        f"{alert['title'][:200]!r}"
+    )
+    print(json.dumps(alert, indent=2, ensure_ascii=False))
+    if not send:
+        print("Dry run complete; no notification sent.")
+        return alert
+
+    if not config.WEBEX_BOT_TOKEN or not config.WEBEX_ROOM_ID:
+        raise RuntimeError("Webex bot token and room ID are required for --send")
+    if not emailer.send_webex_alert([alert]):
+        raise RuntimeError("Webex did not confirm the source-record backfill")
+    print("Source-record backfill sent successfully.")
+    return alert
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot-dir", required=True)
+    parser.add_argument("--date", required=True, type=snapshot_date)
+    parser.add_argument("--kind", required=True, choices=RECORD_KINDS)
+    parser.add_argument("--selector", required=True, type=record_selector)
+    parser.add_argument(
+        "--send",
+        action="store_true",
+        help="Send the selected record; omission performs validation only.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    replay_source_record(
+        args.snapshot_dir,
+        args.date,
+        args.kind,
+        args.selector,
+        send=args.send,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backfill_source_record.py
+++ b/tests/test_backfill_source_record.py
@@ -1,0 +1,119 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from scripts.webex import backfill_source_record
+
+
+def _write_snapshot(tmp_path):
+    payload = {
+        "cc_portal": {
+            "pps": [{
+                "id": "BSI-CC-PP-0105-V4-2026",
+                "title": "SMAERS Protection Profile",
+                "link": "https://www.commoncriteriaportal.org/pp.pdf",
+                "scheme": "DE",
+                "issue_date": "2026-06-01",
+            }],
+            "products": [{
+                "id": "2026.0123",
+                "title": "Secure Router",
+                "vendor": "Vendor A",
+                "certificate_date": "2026-08-01",
+                "link": "https://www.commoncriteriaportal.org/report.pdf",
+            }],
+        },
+        "csfc": {"pages": {"apl": [{
+            "href": "https://www.niap-ccevs.org/products/international-product/2026.1096",
+            "type": "IPsec\u00a0 VPN Client",
+            "text": "Ad Noctem Connect",
+        }] }},
+    }
+    snapshot = tmp_path / "2026-08-29.json"
+    snapshot.write_text(json.dumps(payload), encoding="utf-8")
+    return snapshot
+
+
+@pytest.mark.parametrize(
+    ("kind", "selector", "expected_title"),
+    [
+        ("cc-portal-pp", "BSI-CC-PP-0105-V4-2026", "SMAERS Protection Profile"),
+        ("cc-portal-product", "2026.0123", "Secure Router"),
+        ("csfc-component", "2026.1096|IPsec VPN Client", "Ad Noctem Connect"),
+    ],
+)
+def test_loads_exact_supported_record(tmp_path, kind, selector, expected_title):
+    _write_snapshot(tmp_path)
+
+    record = backfill_source_record.load_source_record(
+        tmp_path, "2026-08-29", kind, selector
+    )
+    alert = backfill_source_record.build_alert(kind, record)
+
+    assert alert["title"] == expected_title
+    assert alert["url"].startswith("https://")
+
+
+def test_missing_or_duplicate_selector_is_rejected(tmp_path):
+    snapshot = _write_snapshot(tmp_path)
+    payload = json.loads(snapshot.read_text())
+    payload["cc_portal"]["products"].append(
+        dict(payload["cc_portal"]["products"][0])
+    )
+    snapshot.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected exactly one"):
+        backfill_source_record.load_source_record(
+            tmp_path, "2026-08-29", "cc-portal-product", "2026.0123"
+        )
+
+
+def test_dry_run_never_sends(tmp_path):
+    _write_snapshot(tmp_path)
+
+    with patch.object(backfill_source_record.emailer, "send_webex_alert") as send:
+        alert = backfill_source_record.replay_source_record(
+            tmp_path,
+            "2026-08-29",
+            "csfc-component",
+            "2026.1096|IPsec VPN Client",
+        )
+
+    send.assert_not_called()
+    assert alert["source"] == "CSfC Components List"
+
+
+def test_send_requires_confirmed_webex_delivery(tmp_path):
+    _write_snapshot(tmp_path)
+
+    with (
+        patch.object(backfill_source_record.config, "WEBEX_BOT_TOKEN", "token"),
+        patch.object(backfill_source_record.config, "WEBEX_ROOM_ID", "room"),
+        patch.object(
+            backfill_source_record.emailer,
+            "send_webex_alert",
+            return_value=False,
+        ),
+        pytest.raises(RuntimeError, match="did not confirm"),
+    ):
+        backfill_source_record.replay_source_record(
+            tmp_path,
+            "2026-08-29",
+            "cc-portal-pp",
+            "BSI-CC-PP-0105-V4-2026",
+            send=True,
+        )
+
+
+def test_http_url_from_snapshot_is_not_rendered_as_clickable(tmp_path):
+    snapshot = _write_snapshot(tmp_path)
+    payload = json.loads(snapshot.read_text())
+    payload["cc_portal"]["products"][0]["link"] = "http://unsafe.test/report.pdf"
+    snapshot.write_text(json.dumps(payload), encoding="utf-8")
+
+    record = backfill_source_record.load_source_record(
+        tmp_path, "2026-08-29", "cc-portal-product", "2026.0123"
+    )
+
+    assert backfill_source_record.build_alert("cc-portal-product", record)["url"] == ""

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -25,6 +25,12 @@ _cfg.SANITY_MIN_PPS = 10
 _cfg.SANITY_MIN_CSFC_APL = 5
 _cfg.SANITY_MIN_CSFC_ANNOUNCEMENTS = 1
 _cfg.SANITY_MIN_CC_CRYPTO_PUBS = 5
+_cfg.SANITY_MIN_CC_PORTAL_NEWS = 1
+_cfg.SANITY_MIN_CC_PORTAL_PPS = 1
+_cfg.SANITY_MIN_CC_PORTAL_PRODUCTS = 1
+_cfg.CC_PORTAL_BASE = "https://www.commoncriteriaportal.org"
+_cfg.CC_PORTAL_EMBEDDED_JSON_MAX_CHARS = 20 * 1024 * 1024
+_cfg.RSS_FEED_MAX_BYTES = 2 * 1024 * 1024
 _cfg.CSFC_BASE = "https://www.nsa.gov"
 _cfg.CSFC_PAGES = {
     "home": "/csfc/",
@@ -260,6 +266,100 @@ class TestGetHtml:
         assert fallback.call_args.kwargs["impersonate"] == "chrome"
         browser_response.raise_for_status.assert_called_once()
 
+
+# ===========================================================================
+# Session-backed RSS parsing and CC Portal embedded JSON
+# ===========================================================================
+
+class TestRssHealth:
+
+    def test_rss_is_parsed_from_bounded_session_bytes(self):
+        payload = b"""<?xml version="1.0"?><rss version="2.0"><channel>
+        <title>CISA</title><item><title>Alert One</title>
+        <link>https://www.cisa.gov/one</link><guid>one</guid></item>
+        </channel></rss>"""
+        fetched = {
+            "content": payload,
+            "url": "https://www.cisa.gov/cybersecurity-advisories/all.xml",
+            "sha256": "abc123",
+        }
+        parsed_feed = MagicMock()
+        parsed_feed.entries = [{
+            "title": "Alert One", "link": "https://www.cisa.gov/one", "id": "one"
+        }]
+        parsed_feed.get.side_effect = lambda key, default=None: {
+            "bozo": False,
+        }.get(key, default)
+        with patch.object(collector, "_fetch_fixed_source", return_value=fetched) as fetch:
+            with patch.object(collector.feedparser, "parse", return_value=parsed_feed) as parse:
+                items, health = collector._get_rss(fetched["url"])
+
+        assert [item["title"] for item in items] == ["Alert One"]
+        assert health["success"] is True
+        assert health["complete"] is True
+        assert health["observed"] == 1
+        assert fetch.call_args.kwargs["max_bytes"] == _cfg.RSS_FEED_MAX_BYTES
+        parse.assert_called_once_with(payload)
+
+    def test_non_https_feed_is_rejected_before_fetch(self):
+        with patch.object(collector, "_fetch_fixed_source") as fetch:
+            items, health = collector._get_rss("http://example.test/feed.xml")
+
+        assert items == []
+        assert health["success"] is False
+        fetch.assert_not_called()
+
+
+class TestCcPortalEmbeddedJson:
+
+    def test_parses_pp_list_with_explicit_stable_identity(self):
+        script = MagicMock()
+        script.string = """var ppList = [{
+          "PPID": 548, "ID": "2026.0010", "Abbr": "BSI-CC-PP-0105-V4-2026",
+          "Name": "Security &amp; Records", "Version": "3.0.2",
+          "PDF_PP": "Protection Profile.pdf", "Issue_Date": "2026-06-01"
+        }];"""
+        soup = MagicMock()
+        soup.find_all.return_value = [script]
+
+        records = collector.parsecc_pps(soup)
+
+        assert records[0]["id"] == "BSI-CC-PP-0105-V4-2026"
+        assert records[0]["portal_id"] == "2026.0010"
+        assert records[0]["internal_id"] == "548"
+        assert records[0]["title"] == "Security & Records"
+        assert records[0]["link"].endswith("Protection%20Profile.pdf")
+
+    def test_parses_product_list_and_normalizes_fields(self):
+        script = MagicMock()
+        script.string = """const productList = [{
+          "id": "2026.0123", "name": "Secure Router", "vendor_name": "Vendor A",
+          "certified": "2026-08-01", "pdf_cert": "report.pdf",
+          "scheme_name": "BSI", "category_name": "Network Devices"
+        }];"""
+        soup = MagicMock()
+        soup.find_all.return_value = [script]
+
+        records = collector.parsecc_products(soup)
+
+        assert records == [{
+            "id": "2026.0123", "product_id": "2026.0123",
+            "title": "Secure Router", "name": "Secure Router", "text": "Secure Router",
+            "vendor": "Vendor A", "scheme": "BSI", "category": "Network Devices",
+            "eal": "", "certificate_date": "2026-08-01", "archive_date": "",
+            "link": "https://www.commoncriteriaportal.org/nfs/ccpfiles/files/epfiles/report.pdf",
+            "certificate_link": "https://www.commoncriteriaportal.org/nfs/ccpfiles/files/epfiles/report.pdf",
+            "security_target_link": "", "vendor_url": "",
+        }]
+
+    def test_non_json_javascript_is_not_executed(self):
+        script = MagicMock()
+        script.string = "var productList = doSomethingDangerous();"
+        soup = MagicMock()
+        soup.find_all.return_value = [script]
+
+        assert collector.parsecc_products(soup) == []
+
 # ===========================================================================
 # collect_csfc — fix #24: APL page fetched once, soup reused
 # ===========================================================================
@@ -319,6 +419,31 @@ class TestCollectCsfc:
     def test_scrape_csfc_page_from_soup_handles_none(self):
         result = collector._scrape_csfc_page_from_soup(None)
         assert result == []
+
+    def test_records_health_for_every_configured_feed(self):
+        mock_soup = MagicMock()
+        mock_soup.find.return_value = None
+        mock_soup.find_all.return_value = []
+        feeds = [{
+            "name": "CISA Alerts",
+            "rss": "https://www.cisa.gov/cybersecurity-advisories/all.xml",
+            "scrape": False,
+            "minimum": 1,
+        }]
+        feed_health = {
+            "success": True, "complete": True, "observed": 1, "detail": ""
+        }
+        with patch.object(_cfg, "CSFC_FEEDS", feeds):
+            with patch.object(collector, "get_html", return_value=mock_soup):
+                with patch.object(
+                    collector,
+                    "_get_rss",
+                    return_value=([{"title": "Alert One", "id": "one"}], feed_health),
+                ):
+                    result = collector.collect_csfc()
+
+        assert result["feeds"]["CISA Alerts"][0]["id"] == "one"
+        assert result["_feed_health"]["CISA Alerts"] == feed_health
 
 
 # ===========================================================================

--- a/tests/test_differ.py
+++ b/tests/test_differ.py
@@ -709,6 +709,46 @@ class TestDiffCsfcApl:
         assert len(result["removed"]) == 1
         assert result["updated"] == []
 
+    def test_same_niap_product_in_new_component_role_is_added(self):
+        """A NIAP validation can legitimately occupy multiple CSfC roles."""
+        old = [{
+            "href": "https://www.niap-ccevs.org/Products/11664?source=csfc",
+            "type": "End User Device / Mobile Platform",
+            "text": "Samsung Galaxy Devices Android 16",
+        }]
+        new = [
+            dict(old[0]),
+            {
+                "href": "https://www.niap-ccevs.org/products/international-product/11664",
+                "type": "IPsec\u00a0 VPN Client",
+                "text": "Samsung Galaxy Devices Android 16",
+            },
+        ]
+
+        result = differ._diff_csfc_apl(old, new)
+
+        assert result["removed"] == []
+        assert result["updated"] == []
+        assert [item["type"] for item in result["added"]] == ["IPsec\u00a0 VPN Client"]
+
+    def test_same_product_and_role_wording_change_is_updated(self):
+        old = [{
+            "href": "https://www.niap-ccevs.org/Products/11664",
+            "type": "IPsec VPN Client",
+            "text": "Samsung Android 16, certified July",
+        }]
+        new = [{
+            "href": "https://www.niap-ccevs.org/products/international-product/11664/",
+            "type": "  IPsec   VPN Client ",
+            "text": "Samsung Android 16 (certified July)",
+        }]
+
+        result = differ._diff_csfc_apl(old, new)
+
+        assert result["added"] == []
+        assert result["removed"] == []
+        assert len(result["updated"]) == 1
+
 
 # ===========================================================================
 # diff_csfc -- routes the "apl" page through _diff_csfc_apl(); other CSfC

--- a/tests/test_emailer_source_health.py
+++ b/tests/test_emailer_source_health.py
@@ -1,0 +1,16 @@
+import emailer
+
+
+def test_auxiliary_feed_degradation_is_not_a_green_daily_heartbeat():
+    health = {
+        "csfc": {
+            "status": "healthy",
+            "auxiliary_status": "degraded",
+            "detail": "auxiliary feed failures: DISA STIGs & APL News",
+        },
+        "niap": {"status": "healthy"},
+    }
+
+    degraded = emailer._degraded_source_health(health)
+
+    assert set(degraded) == {"csfc"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,6 +32,9 @@ _cfg.SANITY_MIN_PPS = 10
 _cfg.SANITY_MIN_CSFC_APL = 5
 _cfg.SANITY_MIN_CSFC_ANNOUNCEMENTS = 1
 _cfg.SANITY_MIN_CC_CRYPTO_PUBS = 5
+_cfg.SANITY_MIN_CC_PORTAL_NEWS = 1
+_cfg.SANITY_MIN_CC_PORTAL_PPS = 1
+_cfg.SANITY_MIN_CC_PORTAL_PRODUCTS = 1
 _cfg.SANITY_MIN_NIAP_NEWS = 1
 _cfg.SANITY_MIN_NIAP_POLICIES = 1
 _cfg.SANITY_MIN_NIAP_PQC_PP_FILES = 1
@@ -43,6 +46,9 @@ _cfg.SANITY_MIN_IETF_CNSA_DOCUMENTS = 5
 _cfg.SANITY_MIN_IEEE_PQC_RECORDS = 1
 _cfg.SANITY_MIN_CSFC_PQC_DOCUMENTS = 5
 _cfg.COLLAPSE_MIN_BASELINE = 8
+_cfg.EUCC_CONTINUITY_MIN_BASELINE = 10
+_cfg.EUCC_MIN_IDENTITY_OVERLAP = 0.70
+_cfg.CSFC_FEEDS = []
 for _mod in (
     "config", "collector", "differ", "dashboard", "emailer",
     "requests", "feedparser", "bs4",
@@ -160,7 +166,11 @@ def _healthy_snapshot():
                 for i in range(10)
             ],
         },
-        "cc_portal": {"news": [{"id": 1}], "pps": [], "products": []},
+        "cc_portal": {
+            "news": [{"id": 1}],
+            "pps": [{"id": "PP-1", "title": "Profile"}],
+            "products": [{"id": "PRODUCT-1", "title": "Product"}],
+        },
         "cctl_labs": {"Test Lab": [{"title": "post"}]},
         "csfc": {"pages": {
             "apl": [{"text": str(i)} for i in range(5)],
@@ -503,6 +513,170 @@ class TestSourceHealth:
 
         assert snapshot["source_health"]["ietf_cnsa"]["status"] == "failed"
         assert "CNSA full-text hashes" in snapshot["source_health"]["ietf_cnsa"]["detail"]
+
+    def test_cc_portal_subcollections_are_checked_independently(self):
+        snapshot = _healthy_snapshot()
+        snapshot["cc_portal"]["pps"] = []
+
+        main._apply_source_health(snapshot)
+
+        health = snapshot["source_health"]["cc_portal"]
+        assert health["status"] == "failed"
+        assert "Protection Profiles 0/1" in health["detail"]
+
+    def test_cc_portal_parser_rollout_baselines_only_new_inventory(self):
+        old = _healthy_snapshot()
+        old["source_health"] = {
+            "cc_portal": {"status": "healthy", "using_last_known_good": False}
+        }
+        old["cc_portal"] = {
+            "news": [{"text": "Old news"}],
+            "pps": [],
+            "products": [{"id": "legacy"}],
+        }
+        new = copy.deepcopy(old)
+        new["cc_portal"] = {
+            "news": [{"text": "Old news"}, {"text": "New news"}],
+            "pps": [{"id": "PP-1"}, {"id": "PP-2"}],
+            "products": [{"id": "P-1"}, {"id": "P-2"}],
+        }
+
+        with patch.object(_cfg, "SANITY_MIN_CC_PORTAL_PPS", 2):
+            with patch.object(_cfg, "SANITY_MIN_CC_PORTAL_PRODUCTS", 2):
+                baseline = main._diff_baseline_with_recoveries(old, new)
+
+        assert baseline["cc_portal"]["pps"] == new["cc_portal"]["pps"]
+        assert baseline["cc_portal"]["products"] == new["cc_portal"]["products"]
+        assert baseline["cc_portal"]["news"] == old["cc_portal"]["news"]
+
+    def test_failed_csfc_feed_retains_only_its_last_known_good(self):
+        feeds = [
+            {"name": "NSA", "rss": "https://www.nsa.gov/feed", "minimum": 1},
+            {"name": "CISA", "rss": "https://www.cisa.gov/feed", "minimum": 1},
+        ]
+        prior = _healthy_snapshot()
+        prior["csfc"].update({
+            "feeds": {
+                "NSA": [{"id": "nsa-old"}],
+                "CISA": [{"id": "cisa-old"}],
+            },
+            "_feed_health": {
+                "NSA": {"success": True, "complete": True, "observed": 1},
+                "CISA": {"success": True, "complete": True, "observed": 1},
+            },
+        })
+        with patch.object(_cfg, "CSFC_FEEDS", feeds):
+            main._apply_source_health(prior)
+            current = copy.deepcopy(prior)
+            current["csfc"]["pages"]["apl"].append({"text": "new APL row"})
+            current["csfc"]["feeds"]["NSA"] = [{"id": "nsa-new"}]
+            current["csfc"]["feeds"]["CISA"] = []
+            current["csfc"]["_feed_health"] = {
+                "NSA": {"success": True, "complete": True, "observed": 1},
+                "CISA": {
+                    "success": False, "complete": False, "observed": 0,
+                    "detail": "malformed response",
+                },
+            }
+
+            main._apply_source_health(current, prior)
+
+        health = current["source_health"]["csfc"]
+        assert health["status"] == "healthy"
+        assert health["auxiliary_status"] == "degraded"
+        assert set(health["subcollections"]) == {"NSA", "CISA"}
+        assert health["subcollections"]["CISA"]["status"] == "stale"
+        assert current["csfc"]["feeds"]["CISA"] == prior["csfc"]["feeds"]["CISA"]
+        assert current["csfc"]["feeds"]["NSA"] == [{"id": "nsa-new"}]
+        assert current["csfc"]["pages"]["apl"][-1]["text"] == "new APL row"
+
+    def test_first_healthy_csfc_feed_is_baselined_without_hiding_apl_change(self):
+        feeds = [{
+            "name": "CISA", "rss": "https://www.cisa.gov/feed", "minimum": 1
+        }]
+        old = _healthy_snapshot()
+        old["csfc"]["feeds"] = {"CISA": []}
+        old["source_health"] = {"csfc": {"status": "healthy"}}
+        new = copy.deepcopy(old)
+        new["csfc"]["pages"]["apl"].append({"text": "new APL component"})
+        new["csfc"]["feeds"]["CISA"] = [{"id": f"alert-{i}"} for i in range(30)]
+        new["source_health"] = {
+            "csfc": {
+                "status": "healthy",
+                "subcollections": {
+                    "CISA": {"status": "healthy", "using_last_known_good": False}
+                },
+            },
+        }
+
+        with patch.object(_cfg, "CSFC_FEEDS", feeds):
+            baseline = main._diff_baseline_with_recoveries(old, new)
+
+        assert baseline["csfc"]["feeds"]["CISA"] == new["csfc"]["feeds"]["CISA"]
+        assert baseline["csfc"]["pages"]["apl"] == old["csfc"]["pages"]["apl"]
+
+    def test_eucc_low_identity_overlap_retains_certificate_baseline(self):
+        prior = _healthy_snapshot()
+        prior_certs = [
+            {"name": f"EUCC-{i}", "cert_date": "2026-01-01", "href": f"https://old/{i}"}
+            for i in range(20)
+        ]
+        prior["eucc"] = {"pages": {"certificates": prior_certs}, "cisco_certs": []}
+        main._apply_source_health(prior)
+        current = copy.deepcopy(prior)
+        current["eucc"]["pages"]["certificates"] = [
+            *copy.deepcopy(prior_certs[:5]),
+            *[
+                {"name": f"NEW-{i}", "cert_date": "2026-08-01", "href": f"https://new/{i}"}
+                for i in range(15)
+            ],
+        ]
+        current["eucc"]["pages"]["requirements"] = [{"text": "Current scheme news"}]
+
+        main._apply_source_health(current, prior)
+
+        health = current["source_health"]["eucc"]
+        assert health["status"] == "stale"
+        assert health["continuity"]["overlap"] == 5
+        assert current["eucc"]["pages"]["certificates"] == prior_certs
+        assert current["eucc"]["pages"]["requirements"] == [{"text": "Current scheme news"}]
+
+    def test_eucc_url_churn_with_same_metadata_is_healthy(self):
+        prior = _healthy_snapshot()
+        prior_certs = [
+            {"name": f"EUCC-{i}", "cert_date": "2026-01-01", "href": f"https://old/{i}"}
+            for i in range(20)
+        ]
+        prior["eucc"] = {"pages": {"certificates": prior_certs}}
+        main._apply_source_health(prior)
+        current = copy.deepcopy(prior)
+        current["eucc"]["pages"]["certificates"] = [
+            {**record, "href": record["href"].replace("https://old/", "https://new/")}
+            for record in prior_certs
+        ]
+
+        main._apply_source_health(current, prior)
+
+        health = current["source_health"]["eucc"]
+        assert health["status"] == "healthy"
+        assert health["continuity"]["overlap"] == 20
+        assert current["eucc"]["pages"]["certificates"][0]["href"].startswith("https://new/")
+
+    def test_eucc_small_high_overlap_shrink_is_healthy(self):
+        prior = _healthy_snapshot()
+        prior_certs = [
+            {"name": f"EUCC-{i}", "cert_date": "2026-01-01", "href": f"https://old/{i}"}
+            for i in range(20)
+        ]
+        prior["eucc"] = {"pages": {"certificates": prior_certs}}
+        main._apply_source_health(prior)
+        current = copy.deepcopy(prior)
+        current["eucc"]["pages"]["certificates"] = copy.deepcopy(prior_certs[:18])
+
+        main._apply_source_health(current, prior)
+
+        assert current["source_health"]["eucc"]["status"] == "healthy"
+        assert len(current["eucc"]["pages"]["certificates"]) == 18
 
     def test_third_failure_triggers_operational_notification(self):
         _cfg.DRY_RUN = False


### PR DESCRIPTION
Summary

- Parse CC Portal ppList and productList embedded JSON into stable, normalized PP and product records.
- Key CSfC Components List entries by NIAP product plus component role, covering the Samsung Android 16 same-URL case.
- Fetch RSS through the bounded project HTTP session and report independent NSA, CISA, and DISA feed health.
- Add EUCC certificate continuity checks using URL or product metadata and certificate date.
- Baseline parser/feed rollouts without suppressing unrelated news or APL changes.
- Add an exact-record, dry-by-default replay path for reviewed CC Portal and CSfC backfills.

Live dry verification on 2026-08-29

- CC Portal: 179 news, 286 PPs, 1773 products.
- EUCC: 67 requirements, 50 certificates, 1 Cisco certificate; identity overlap 50/50.
- CSfC: 123 APL rows; NSA feed 20; CISA feed 30.
- DISA remains 0 because the current Salesforce page is not parsed. It is now explicitly degraded in source health and the daily heartbeat.
- End-to-end diff simulation against the production snapshot produced 0 CC Portal rollout additions, 0 CISA rollout additions, and 0 false alerts.

Prepared exact replay selectors

- PP: BSI-CC-PP-0105-V4-2026
- Products: 2026.1265, 2026.1270, 2026.1268, 2026.1274, 2026.1273
- CSfC: 11664|End User Device / Mobile Platform
- CSfC: 11664|IPsec VPN Client
- CSfC: 2026.1096|IPsec VPN Client

The replay workflow defaults to dry run and requires one exact match plus confirmed Webex delivery before reporting a live send as successful.

Verification

- 262 tests passed.
- Ruff static correctness checks passed.
- GitHub Actions workflow YAML parsed successfully.
- Diff whitespace checks and Python compilation passed.

Security review

- No page JavaScript is executed; embedded data is decoded as bounded JSON only.
- Feed fetches require HTTPS, enforce redirect host allow-lists, timeouts, and response-size caps.
- Replay inputs validate dates, selectors, paths, record uniqueness, snapshot size, and HTTPS links.
- No credentials or weakened TLS/certificate validation were introduced.